### PR TITLE
feat(jsonmodem): pre-allocate buffers to reduce resize costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ the user with minimal latency.
 
 | chunks |     jsonmodem   |  parse_partial_json  |  partial_json_fixer  | speed-up\* |
 | -----: | --------------: | -------------------: | -------------------: | ---------: |
-|    100 |      **121 µs** |             1 627 µs |             1 552 µs |  **12.8×** |
-|  1 000 |      **250 µs** |            16 325 µs |            15 345 µs |  **61.3×** |
-|  5 000 |      **824 µs** |            81 619 µs |            76 613 µs |  **93.0×** |
+|    100 |      **105 µs** |             1 627 µs |             1 552 µs |  **14.8×** |
+|  1 000 |      **245 µs** |            16 325 µs |            15 345 µs |  **62.6×** |
+|  5 000 |      **844 µs** |            81 619 µs |            76 613 µs |  **90.8×** |
 
 \* Versus the fastest helper (`partial_json_fixer`). Benchmarked with Criterion.
 

--- a/crates/jsonmodem/benches/parse_partial_json_port.rs
+++ b/crates/jsonmodem/benches/parse_partial_json_port.rs
@@ -364,7 +364,7 @@ pub fn fix_json(input: &str) -> String {
         #[allow(clippy::cast_sign_loss)]
         input[..=(last_valid_index as usize)].to_owned()
     } else {
-        String::new()
+        String::with_capacity(1024)
     };
 
     // Close any open constructs by unwinding the stack.

--- a/crates/jsonmodem/src/event.rs
+++ b/crates/jsonmodem/src/event.rs
@@ -634,7 +634,7 @@ fn append_string_at_path(target: &mut Value, path: &[PathComponent], fragment: &
                     vec[*i] = Value::String(String::from(fragment));
                 }
             } else {
-                let mut vec = Vec::new();
+                let mut vec = Vec::with_capacity(*i + 1);
                 if *i >= vec.len() {
                     vec.resize(*i + 1, Value::Null);
                 }

--- a/crates/jsonmodem/src/event_stack.rs
+++ b/crates/jsonmodem/src/event_stack.rs
@@ -42,7 +42,7 @@ impl EventStack {
                 ParseEvent::String { fragment, path, .. } => {
                     builder.mutate_with(
                         path.last(),
-                        || Value::String(String::new()),
+                        || Value::String(String::with_capacity(1024)),
                         |v| {
                             if let Value::String(s) = v {
                                 s.push_str(fragment);
@@ -59,7 +59,7 @@ impl EventStack {
                     builder.enter_with(path.last(), || Value::Object(Map::new()))?;
                 }
                 ParseEvent::ArrayStart { path } => {
-                    builder.enter_with(path.last(), || Value::Array(Vec::new()))?;
+                    builder.enter_with(path.last(), || Value::Array(Vec::with_capacity(16)))?;
                 }
 
                 // ── container ends ─────────────────────────────────────────

--- a/crates/jsonmodem/src/tests/parse_bad.rs
+++ b/crates/jsonmodem/src/tests/parse_bad.rs
@@ -222,7 +222,7 @@ fn error_control_characters_escaped_in_message() {
 fn unclosed_objects_before_property_names() {
     let mut parser = StreamingParser::new(ParserOptions {
         emit_non_scalar_values: true,
-        ..Default::default()
+        ..ParserOptions::default()
     });
     parser.feed("{");
     // Drive the parser to process the already-fed chunk so that the builder is

--- a/crates/jsonmodem/src/value_zipper.rs
+++ b/crates/jsonmodem/src/value_zipper.rs
@@ -19,9 +19,9 @@ impl ValueZipper {
     pub fn new(value: Value) -> Self {
         Self {
             root: Box::new(value),
-            path: Vec::new(),
+            path: Vec::with_capacity(16),
             #[cfg(test)]
-            path_components: Vec::new(),
+            path_components: Vec::with_capacity(16),
         }
     }
 
@@ -468,7 +468,7 @@ impl StreamingParserBuilder {
     ) -> Result<Option<(&Value, Vec<ParseEvent>)>, ZipperError> {
         self.parser.feed(buffer);
 
-        let mut events: Vec<ParseEvent> = Vec::new();
+        let mut events: Vec<ParseEvent> = Vec::with_capacity(16);
         for evt in self.parser.by_ref() {
             match evt {
                 Ok(event) => events.push(event),
@@ -494,7 +494,7 @@ impl StreamingParserBuilder {
                 ParseEvent::String { fragment, path, .. } => {
                     self.state.mutate_with(
                         path.last(),
-                        || Value::String(String::new()),
+                        || Value::String(String::with_capacity(1024)),
                         |v| {
                             if let Value::String(s) = v {
                                 s.push_str(fragment);
@@ -515,7 +515,7 @@ impl StreamingParserBuilder {
                 }
                 ParseEvent::ArrayStart { path } => {
                     self.state
-                        .enter_with(path.last(), || Value::Array(Vec::new()))?;
+                        .enter_with(path.last(), || Value::Array(Vec::with_capacity(16)))?;
                 }
 
                 // ── container ends ─────────────────────────────────────────
@@ -719,7 +719,7 @@ mod tests {
         zipper
             .mutate_lazy(
                 PathComponent::Key("s".into()),
-                || Value::String(String::new()),
+                || Value::String(String::with_capacity(1024)),
                 |v| {
                     if let Value::String(s) = v {
                         s.push_str("hello");


### PR DESCRIPTION
Avoids resizing string buffers from small N elements to a larger N repeatedly, a larger initial allocation reduce O(log n) resizes to O(1) for many small strings. Also allocates more buffers up front to improve performance and unblock using an object pool of "warmed" streaming parsers off a request handling thread.

Update: Benchmarking shows the largest improvement in the "larger chunk size" tests, which makes sense as we are reducing string buffer resizes while parsing the 10 to 100 fragments. Using a small string optimization may be the right path to split the difference here, and avoid heap allocations in the hot path for the `/5000` case.