### PR TITLE
Add StreamingValuesParser tests

### DIFF
--- a/crates/jsonmodem/src/tests/mod.rs
+++ b/crates/jsonmodem/src/tests/mod.rs
@@ -4,6 +4,8 @@ mod parse_good;
 mod property_multivalue;
 mod property_partition;
 mod repro;
+mod streaming_values_good;
 pub mod utils;
 
 mod snapshot_events;
+mod streaming_values_bad;

--- a/crates/jsonmodem/src/tests/streaming_values_bad.rs
+++ b/crates/jsonmodem/src/tests/streaming_values_bad.rs
@@ -1,0 +1,492 @@
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+
+use crate::{
+    ParserOptions, StreamingValue, StreamingValuesParser, Value, options::NonScalarValueMode,
+    value::Map,
+};
+
+#[test]
+fn error_empty_document() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    parser.feed("").expect("feed failed");
+    let err = parser.finish().unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid end of input");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn error_comment() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("/").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '/' at 1:1");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn error_invalid_characters_in_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("a").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:1");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn error_invalid_property_name() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("{\\a:1}").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '\\\\' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_escaped_property_names() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    // Hex escapes not accepted as property names
+    assert!(
+        parser
+            .feed("{\\u0061\\u0062:1,\\u0024\\u005F:2,\\u005F\\u0024:3}")
+            .is_err()
+    );
+}
+
+#[test]
+fn error_invalid_identifier_start_characters() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+
+    let err = parser.feed("{\\u0021:1}").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '\\\\' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_invalid_characters_following_sign() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("-a").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_invalid_characters_following_exponent_indicator() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("1ea").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_invalid_characters_following_exponent_sign() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("1e-a").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:4");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 4);
+}
+
+#[test]
+fn error_invalid_new_lines_in_strings() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\"\n\"").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '\\n' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_invalid_identifier_in_property_names() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("{!:1}").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '!' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_invalid_characters_following_array_value() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("[1!]").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '!' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_invalid_characters_in_literals() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("tru!").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '!' at 1:4");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 4);
+}
+
+#[test]
+fn error_unterminated_escapes() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    parser.feed("\"\\").expect("feed failed");
+    let err = parser.finish().unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid end of input");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_invalid_first_digits_in_hexadecimal_escapes() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\"\\xg\"").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'x' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_invalid_second_digits_in_hexadecimal_escapes() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\"\\x0g\"").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'x' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_invalid_unicode_escapes() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\"\\u000g\"").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'g' at 1:7");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 7);
+}
+
+// Escaped digits 1–9
+#[test]
+fn error_escaped_digit_1_to_9() {
+    for i in 1..=9 {
+        let mut parser = StreamingValuesParser::new(ParserOptions {
+            non_scalar_values: NonScalarValueMode::All,
+            ..Default::default()
+        });
+        let s = format!("\"\\{i}\"");
+        let err = parser.feed(&s).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("JSON5: invalid character '{i}' at 1:3")
+        );
+        assert_eq!(err.line, 1);
+        assert_eq!(err.column, 3);
+    }
+}
+
+#[test]
+fn error_octal_escapes() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\"\\01\"").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '0' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_multiple_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("1 2").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '2' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_control_characters_escaped_in_message() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("\x01").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '\\u0001' at 1:1");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn unclosed_objects_before_property_names() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let vals = parser.feed("{").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::Object(Map::new()),
+            is_final: false,
+        }]
+    );
+}
+
+#[test]
+fn unclosed_objects_after_property_names() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let vals = parser.feed("{\"a\"").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::Object(Map::new()),
+            is_final: false,
+        }]
+    );
+}
+
+#[test]
+fn error_unclosed_objects_before_property_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("{a:").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_unclosed_objects_after_property_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("{a:1").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'a' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn unclosed_arrays_before_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let vals = parser.feed("[").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::Array(Vec::new()),
+            is_final: false,
+        }]
+    );
+}
+
+#[test]
+fn unclosed_arrays_after_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let vals = parser.feed("[").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::Array(Vec::new()),
+            is_final: false,
+        }]
+    );
+}
+
+#[test]
+fn error_number_with_leading_zero() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("0x").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'x' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_nan() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("NaN").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'N' at 1:1");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn error_infinity() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("[Infinity,-Infinity]").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character 'I' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_leading_decimal_points() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("[.1,.23]").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '.' at 1:2");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 2);
+}
+
+#[test]
+fn error_trailing_decimal_points() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("[0.]").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character ']' at 1:4");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 4);
+}
+
+#[test]
+fn error_leading_plus_in_number() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let err = parser.feed("+1.23e100").unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character '+' at 1:1");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 1);
+}
+
+#[test]
+fn error_incorrectly_completed_partial_string() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+    let vals = parser.feed("\"abc").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::String(String::from("abc")),
+            is_final: false,
+        }]
+    );
+    let err = parser.feed("\"{}").unwrap_err();
+    // error: invalid character '{' at position 6 of the stream
+    assert_eq!(err.to_string(), "JSON5: invalid character '{' at 1:6");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 6);
+}
+
+#[test]
+fn error_incorrectly_completed_partial_string_with_suffixes() {
+    for &suffix in &["null", "\"", "1", "true", "{}", "[]"] {
+        let mut parser = StreamingValuesParser::new(ParserOptions {
+            non_scalar_values: NonScalarValueMode::All,
+            ..Default::default()
+        });
+        let vals = parser.feed("\"abc").expect("feed failed");
+        assert_eq!(
+            vals,
+            vec![StreamingValue {
+                index: 0,
+                value: Value::String(String::from("abc")),
+                is_final: false,
+            }]
+        );
+        let error_char = if suffix == "\"" {
+            "\\\""
+        } else {
+            &suffix[0..1]
+        };
+        let err = parser.feed(&format!("\"{suffix}")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("JSON5: invalid character '{error_char}' at 1:6")
+        );
+        assert_eq!(err.line, 1);
+        assert_eq!(err.column, 6);
+    }
+}

--- a/crates/jsonmodem/src/tests/streaming_values_good.rs
+++ b/crates/jsonmodem/src/tests/streaming_values_good.rs
@@ -1,0 +1,267 @@
+use alloc::{string::ToString, vec, vec::Vec};
+
+use crate::{
+    StreamingValue, StreamingValuesParser, Value,
+    options::{NonScalarValueMode, ParserOptions},
+    value::Map,
+};
+
+/// Helper to feed JSON chunks and return the final Value via builder-based
+/// `current_value()`. Unlike the TS parser, we do _not_ emit a complete string
+/// Value event, so we enable non-scalar-value building and inspect
+/// `current_value()` directly.
+fn finish_seq(chunks: &[&str]) -> Value {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        string_value_mode: crate::StringValueMode::Values,
+        ..Default::default()
+    });
+    let mut values = Vec::<StreamingValue>::new();
+    for &chunk in chunks {
+        values.extend(parser.feed(chunk).expect("feed failed"));
+    }
+    values.extend(parser.finish().expect("finish failed"));
+
+    values
+        .last()
+        .expect("must have at least one value")
+        .value
+        .clone()
+}
+
+#[test]
+fn test_empty_object() {
+    assert_eq!(finish_seq(&["{}"]), Value::Object(Map::new()));
+}
+
+#[test]
+fn test_single_property() {
+    let mut map = Map::new();
+    map.insert("a".to_string(), Value::Number(1.0));
+    assert_eq!(finish_seq(&["{\"a\":1}"]), Value::Object(map));
+}
+
+#[test]
+fn test_multiple_properties() {
+    let mut map = Map::new();
+    map.insert("abc".to_string(), Value::Number(1.0));
+    map.insert("def".to_string(), Value::Number(2.0));
+    assert_eq!(finish_seq(&["{\"abc\":1,\"def\":2}"]), Value::Object(map));
+}
+
+#[test]
+fn test_nested_objects() {
+    let mut inner = Map::new();
+    inner.insert("b".to_string(), Value::Number(2.0));
+
+    let mut outer = Map::new();
+    outer.insert("a".to_string(), Value::Object(inner));
+
+    assert_eq!(finish_seq(&["{\"a\":{\"b\":2}}"]), Value::Object(outer));
+}
+
+#[test]
+fn test_arrays() {
+    assert_eq!(finish_seq(&["[]"]), Value::Array(vec![]));
+    assert_eq!(finish_seq(&["[1]"]), Value::Array(vec![Value::Number(1.0)]));
+    assert_eq!(
+        finish_seq(&["[1,2]"]),
+        Value::Array(vec![Value::Number(1.0), Value::Number(2.0)])
+    );
+    assert_eq!(
+        finish_seq(&["[1,[2,3]]"]),
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Array(vec![Value::Number(2.0), Value::Number(3.0)]),
+        ])
+    );
+}
+
+#[test]
+fn test_literals() {
+    assert_eq!(finish_seq(&["null"]), Value::Null);
+    assert_eq!(finish_seq(&["true"]), Value::Boolean(true));
+    assert_eq!(finish_seq(&["false"]), Value::Boolean(false));
+}
+
+#[test]
+fn test_numbers() {
+    assert_eq!(
+        finish_seq(&["[-0]"]),
+        Value::Array(vec![Value::Number(-0.0)])
+    );
+
+    assert_eq!(
+        finish_seq(&["[1,23,456,7890]"]),
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(23.0),
+            Value::Number(456.0),
+            Value::Number(7890.0),
+        ])
+    );
+
+    assert_eq!(
+        finish_seq(&["[-1,-2,-0.1,-0]"]),
+        Value::Array(vec![
+            Value::Number(-1.0),
+            Value::Number(-2.0),
+            Value::Number(-0.1),
+            Value::Number(-0.0),
+        ])
+    );
+
+    assert_eq!(
+        finish_seq(&["[1.0,1.23]"]),
+        Value::Array(vec![Value::Number(1.0), Value::Number(1.23)])
+    );
+
+    assert_eq!(
+        finish_seq(&["[1e0,1e-1,1e+1,1.1e0]"]),
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(0.1),
+            Value::Number(10.0),
+            Value::Number(1.1),
+        ])
+    );
+}
+
+#[test]
+fn test_preserves_proto_property() {
+    let mut map = Map::new();
+    map.insert("__proto__".to_string(), Value::Number(1.0));
+    assert_eq!(finish_seq(&["{\"__proto__\":1}"]), Value::Object(map));
+}
+
+#[test]
+fn test_exponents_more_forms() {
+    assert_eq!(
+        finish_seq(&["[1e0,1e1,1e-1,1e+1,1.1e0]"]),
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(10.0),
+            Value::Number(0.1),
+            Value::Number(10.0),
+            Value::Number(1.1),
+        ])
+    );
+}
+
+#[test]
+fn test_partial_string_multiple_feeds() {
+    assert_eq!(
+        finish_seq(&["\"abc", "def", "ghi\""]),
+        Value::String("abcdefghi".into())
+    );
+}
+
+#[test]
+fn test_continue_after_array_value() {
+    assert_eq!(
+        finish_seq(&["[\"1\"", ",\"2\"", "]"]),
+        Value::Array(vec![Value::String("1".into()), Value::String("2".into())])
+    );
+}
+
+#[test]
+fn test_continue_within_array_value() {
+    assert_eq!(
+        finish_seq(&["[\"1\"", ",\"2", "3\"", ",4]"]),
+        Value::Array(vec![
+            Value::String("1".into()),
+            Value::String("23".into()),
+            Value::Number(4.0),
+        ])
+    );
+}
+
+#[test]
+fn test_continue_string_with_escape() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+
+    // Feed the opening quote of the string – this is not enough to complete
+    // a JSON value, so we should not receive any events yet and `current_value`
+    // must stay `None`.
+    let vals = parser.feed("\"").expect("feed failed");
+    assert!(vals.is_empty());
+
+    // Feed a backslash – still inside the string escape sequence, which is
+    // incomplete at this point. Again, we must not observe any completed
+    // events and `current_value` should remain unset.
+    let vals = parser.feed("\\").expect("feed failed");
+    assert!(vals.is_empty());
+}
+
+#[test]
+fn test_integer_split_across_feeds() {
+    assert_eq!(finish_seq(&["-", "12"]), Value::Number(-12.0));
+}
+
+#[test]
+fn test_strings_and_escapes() {
+    assert_eq!(finish_seq(&["\"abc\""]), Value::String("abc".into()));
+
+    assert_eq!(
+        finish_seq(&["[\"\\\"\",\"'\"]"]),
+        Value::Array(vec![Value::String("\"".into()), Value::String("'".into())])
+    );
+
+    assert_eq!(
+        finish_seq(&["\"\\b\\f\\n\\r\\t\\u01FF\\\\\\\"\""]),
+        Value::String("\x08\x0C\n\r\t\u{01FF}\\\"".into())
+    );
+}
+
+#[test]
+fn test_whitespace_inside() {
+    assert_eq!(finish_seq(&["{\t\n  \r}\n"]), Value::Object(Map::new()));
+}
+
+#[test]
+fn test_incremental_complete_after_three_feeds() {
+    let v = finish_seq(&["{\"a\": 1", " , \"b\": [2", ",3]} "]);
+    if let Value::Object(map) = v {
+        assert_eq!(map.get("a"), Some(&Value::Number(1.0)));
+    } else {
+        panic!("expected object");
+    }
+}
+
+#[test]
+fn test_streaming_multiple_values() {
+    let mut parser = StreamingValuesParser::new(ParserOptions {
+        allow_multiple_json_values: true,
+        non_scalar_values: NonScalarValueMode::All,
+        ..Default::default()
+    });
+
+    // First chunk – should yield exactly one number value `1`.
+    let vals = parser.feed("1 ").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 0,
+            value: Value::Number(1.0),
+            is_final: true,
+        }]
+    );
+
+    // Second chunk – should yield exactly one number value `2`.
+    let vals = parser.feed(" 2 ").expect("feed failed");
+    assert_eq!(
+        vals,
+        vec![StreamingValue {
+            index: 1,
+            value: Value::Number(2.0),
+            is_final: true,
+        }]
+    );
+
+    // Third chunk – whitespace only, should not emit any values.
+    let vals = parser.feed("   ").expect("feed failed");
+    assert!(vals.is_empty());
+}

--- a/fuzz/fuzz_targets/fuzz_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_parser.rs
@@ -2,7 +2,7 @@
 use std::cell::RefCell;
 
 use arbitrary::Arbitrary;
-use jsonmodem::{ParserOptions, StreamingParser, StringValueMode};
+use jsonmodem::{ParserOptions, StreamingParser, StringValueMode, NonScalarValueMode};
 use libfuzzer_sys::{fuzz_mutator, fuzz_target, fuzzer_mutate};
 use rand::rngs::SmallRng; // faster than StdRng
 use rand::{Rng, RngCore, SeedableRng};
@@ -168,7 +168,11 @@ fn parser(data: &[u8]) {
     let chunks = split_into_safe_chunks(&str, split_seed);
     let mut parser = StreamingParser::new(ParserOptions {
         allow_multiple_json_values: flags & 1 != 0,
-        emit_non_scalar_values: flags & 2 != 0,
+        non_scalar_values: if flags & 2 != 0 {
+            NonScalarValueMode::All
+        } else {
+            NonScalarValueMode::None
+        },
         allow_unicode_whitespace: flags & 4 != 0,
         // Take two bits of the flags, and map them to StringValueMode::None,
         // StringValueMode::Values, StringValueMode::Prefixes,


### PR DESCRIPTION
## Summary
- add parse_good/bad-style tests for `StreamingValuesParser`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6876c9b638d8832097051fd4aa8e31ac