### PR TITLE
Improve streaming parser number lexing

### DIFF
--- a/crates/jsonmodem/src/parser.rs
+++ b/crates/jsonmodem/src/parser.rs
@@ -840,6 +840,14 @@ impl StreamingParser {
                 Char(c) if c.is_ascii_digit() => {
                     self.advance_char();
                     self.buffer.push(c);
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 _ => {
@@ -861,6 +869,14 @@ impl StreamingParser {
                     self.advance_char();
                     self.buffer.push(c);
                     self.lex_state = DecimalFraction;
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 c => Err(self.read_and_invalid_char(c)),
@@ -877,6 +893,14 @@ impl StreamingParser {
                 Char(c) if c.is_ascii_digit() => {
                     self.advance_char();
                     self.buffer.push(c);
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 _ => {
@@ -898,6 +922,14 @@ impl StreamingParser {
                     self.advance_char();
                     self.buffer.push(c);
                     self.lex_state = DecimalExponentInteger;
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 c => Err(self.read_and_invalid_char(c)),
@@ -909,6 +941,14 @@ impl StreamingParser {
                     self.advance_char();
                     self.buffer.push(c);
                     self.lex_state = DecimalExponentInteger;
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 c => Err(self.read_and_invalid_char(c)),
@@ -919,6 +959,14 @@ impl StreamingParser {
                 Char(c) if c.is_ascii_digit() => {
                     self.advance_char();
                     self.buffer.push(c);
+
+                    let copied = self
+                        .source
+                        .copy_while(&mut self.buffer, |d| d.is_ascii_digit());
+
+                    self.column += copied;
+                    self.pos += copied;
+
                     Ok(None)
                 }
                 _ => {


### PR DESCRIPTION
## Summary
- batch copy digits in parser's numeric states to reduce per-character overhead

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_687abda68fb48320b85e5a571bd67ca5