### PR TITLE
Optimize FrameStack cloning

### DIFF
--- a/crates/jsonmodem/src/parser.rs
+++ b/crates/jsonmodem/src/parser.rs
@@ -176,7 +176,7 @@ impl Frame {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FrameStack {
     root: Option<Frame>,
     stack: Vec<(PathComponent, Frame)>,
@@ -188,11 +188,22 @@ impl Default for FrameStack {
     }
 }
 
+impl Clone for FrameStack {
+    fn clone(&self) -> Self {
+        let mut stack = Vec::with_capacity(self.stack.len());
+        stack.extend(self.stack.iter().cloned());
+        Self {
+            root: self.root.clone(),
+            stack,
+        }
+    }
+}
+
 impl FrameStack {
     pub fn new() -> Self {
         Self {
             root: None,
-            stack: Vec::new(),
+            stack: Vec::with_capacity(16),
         }
     }
 


### PR DESCRIPTION
## Summary
- implement a custom `Clone` for `FrameStack` to preallocate
- benchmark `partial_json` suite

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)` & `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_687ac95ca6748320ae1183d3d4116af1