### PR TITLE
Add comparison bench feature

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -30,13 +30,19 @@ other utilities required to build the fuzz crate.
 
 ## Benchmarks
 
-The default `cargo bench` command runs only jsonmodem's own benchmarks. To run
-the comparative suites as well, enable the optional `comparison` feature. The
-following commands produce concise timings suitable for copy‑pasting:
+The default `cargo bench` command runs only jsonmodem's own benchmarks. The
+partial JSON benchmarks skip the `serde`, `jiter`, and fix‑JSON variants unless
+the optional `comparison` feature is enabled. The following commands produce
+concise timings suitable for copy‑pasting:
 
 ```bash
 # jsonmodem benchmarks
 cargo bench --bench streaming_parser -- --output-format bencher | rg '^test'
+
+# sample output
+# test streaming_parser_split/100  ... bench:   48241 ns/iter (+/- 1145)
+# test streaming_parser_split/1000 ... bench:  161009 ns/iter (+/- 4103)
+# test streaming_parser_split/5000 ... bench:  604477 ns/iter (+/- 8785)
 
 # include external implementations
 cargo bench --features comparison --bench partial_json_big -- --output-format bencher | rg '^test'

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -27,3 +27,17 @@ bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/down
 The `setup.sh` script installs the stable and nightly toolchains as well as
 Clang 19 and the `llvm-tools-preview` component, which provide `llvm-nm` and
 other utilities required to build the fuzz crate.
+
+## Benchmarks
+
+The default `cargo bench` command runs only jsonmodem's own benchmarks. To run
+the comparative suites as well, enable the optional `comparison` feature. The
+following commands produce concise timings suitable for copy‑pasting:
+
+```bash
+# jsonmodem benchmarks
+cargo bench --bench streaming_parser -- --output-format bencher | rg '^test'
+
+# include external implementations
+cargo bench --features comparison --bench partial_json_big -- --output-format bencher | rg '^test'
+```

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -36,13 +36,16 @@ the optional `comparison` feature is enabled. The following commands produce
 concise timings suitable for copy‑pasting:
 
 ```bash
-# jsonmodem benchmarks
+# jsonmodem benchmarks only
 cargo bench --bench streaming_parser -- --output-format bencher | rg '^test'
 
 # sample output
 # test streaming_parser_split/100  ... bench:   48241 ns/iter (+/- 1145)
 # test streaming_parser_split/1000 ... bench:  161009 ns/iter (+/- 4103)
 # test streaming_parser_split/5000 ... bench:  604477 ns/iter (+/- 8785)
+
+# partial JSON benchmarks
+cargo bench --bench partial_json_big -- --output-format bencher | rg '^test'
 
 # include external implementations
 cargo bench --features comparison --bench partial_json_big -- --output-format bencher | rg '^test'

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -48,17 +48,14 @@ suspicious = "deny"
 [[bench]]
 name = "partial_json_strategies"
 harness = false
-required-features = ["comparison"]
 
 [[bench]]
 name = "partial_json_big"
 harness = false
-required-features = ["comparison"]
 
 [[bench]]
 name = "partial_json_incremental"
 harness = false
-required-features = ["comparison"]
 
 [[bench]]
 name = "streaming_parser"

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 fuzzing = []
 serde = []
 bench = []
+comparison = []
 
 [dependencies]
 ouroboros = { version = "0.18.5", default-features = false }
@@ -47,14 +48,17 @@ suspicious = "deny"
 [[bench]]
 name = "partial_json_strategies"
 harness = false
+required-features = ["comparison"]
 
 [[bench]]
 name = "partial_json_big"
 harness = false
+required-features = ["comparison"]
 
 [[bench]]
 name = "partial_json_incremental"
 harness = false
+required-features = ["comparison"]
 
 [[bench]]
 name = "streaming_parser"
@@ -63,3 +67,4 @@ harness = false
 [[bench]]
 name = "competitive_benchmarks"
 harness = false
+required-features = ["comparison"]

--- a/crates/jsonmodem/benches/competitive_benchmarks.rs
+++ b/crates/jsonmodem/benches/competitive_benchmarks.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![cfg(feature = "comparison")]
 //! Benchmark comparison of jiter, `serde_json`, and jsonmodem
 //!
 //! ```text

--- a/crates/jsonmodem/benches/parse_partial_json_port.rs
+++ b/crates/jsonmodem/benches/parse_partial_json_port.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::enum_glob_use)]
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::cast_possible_wrap)]
-#![cfg(feature = "comparison")]
 
 use serde_json::Value as JsonValue;
 

--- a/crates/jsonmodem/benches/parse_partial_json_port.rs
+++ b/crates/jsonmodem/benches/parse_partial_json_port.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::enum_glob_use)]
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::cast_possible_wrap)]
+#![cfg(feature = "comparison")]
 
 use serde_json::Value as JsonValue;
 

--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;

--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -1,5 +1,4 @@
 #![allow(missing_docs)]
-#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;
@@ -51,6 +50,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("fix_json_parse", parts),
             &parts,
@@ -62,6 +62,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(BenchmarkId::new("jiter_partial", parts), &parts, |b, &p| {
             b.iter(|| {
                 let v = run_jiter_partial(black_box(&payload), p);
@@ -69,6 +70,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             });
         });
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("jiter_partial_owned", parts),
             &parts,

--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -4,9 +4,10 @@ mod partial_json_common;
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+#[cfg(feature = "comparison")]
+use partial_json_common::{run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned};
 use partial_json_common::{
-    run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned, run_parse_partial_json,
-    run_streaming_parser, run_streaming_values_parser,
+    run_parse_partial_json, run_streaming_parser, run_streaming_values_parser,
 };
 
 fn bench_partial_json_big(c: &mut Criterion) {

--- a/crates/jsonmodem/benches/partial_json_common.rs
+++ b/crates/jsonmodem/benches/partial_json_common.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
-#![cfg(feature = "comparison")]
 
 #[path = "parse_partial_json_port.rs"]
 pub mod parse_partial_json_port;
@@ -73,6 +72,7 @@ pub fn run_parse_partial_json(payload: &str, parts: usize) -> usize {
     calls
 }
 
+#[cfg(feature = "comparison")]
 pub mod partial_json_fixer {
     use serde_json::Value;
 
@@ -85,6 +85,7 @@ pub mod partial_json_fixer {
     }
 }
 
+#[cfg(feature = "comparison")]
 pub fn run_fix_json_parse(payload: &str, parts: usize) -> usize {
     let chunk_size = payload.len().div_ceil(parts);
     let mut buf = String::with_capacity(payload.len());
@@ -99,6 +100,7 @@ pub fn run_fix_json_parse(payload: &str, parts: usize) -> usize {
     calls
 }
 
+#[cfg(feature = "comparison")]
 pub fn run_jiter_partial(payload: &str, parts: usize) -> usize {
     use jiter::{JsonValue, PartialMode};
 
@@ -116,6 +118,7 @@ pub fn run_jiter_partial(payload: &str, parts: usize) -> usize {
     calls
 }
 
+#[cfg(feature = "comparison")]
 pub fn run_jiter_partial_owned(payload: &str, parts: usize) -> usize {
     use jiter::{JsonValue, PartialMode};
 

--- a/crates/jsonmodem/benches/partial_json_common.rs
+++ b/crates/jsonmodem/benches/partial_json_common.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
+#![cfg(feature = "comparison")]
 
 #[path = "parse_partial_json_port.rs"]
 pub mod parse_partial_json_port;

--- a/crates/jsonmodem/benches/partial_json_incremental.rs
+++ b/crates/jsonmodem/benches/partial_json_incremental.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;

--- a/crates/jsonmodem/benches/partial_json_incremental.rs
+++ b/crates/jsonmodem/benches/partial_json_incremental.rs
@@ -1,5 +1,4 @@
 #![allow(missing_docs)]
-#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;
@@ -103,6 +102,7 @@ fn bench_partial_json_incremental(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("fix_json_parse_inc", parts),
             &parts,
@@ -122,6 +122,7 @@ fn bench_partial_json_incremental(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("jiter_partial_inc", parts),
             &parts,
@@ -146,6 +147,7 @@ fn bench_partial_json_incremental(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("jiter_partial_inc_owned", parts),
             &parts,

--- a/crates/jsonmodem/benches/partial_json_incremental.rs
+++ b/crates/jsonmodem/benches/partial_json_incremental.rs
@@ -7,7 +7,9 @@ use criterion::{BatchSize, BenchmarkId, Criterion, black_box, criterion_group, c
 use jsonmodem::{
     NonScalarValueMode, ParserOptions, StreamingParser, StreamingValuesParser, StringValueMode,
 };
-use partial_json_common::{make_json_payload, parse_partial_json_port, partial_json_fixer};
+#[cfg(feature = "comparison")]
+use partial_json_common::partial_json_fixer;
+use partial_json_common::{make_json_payload, parse_partial_json_port};
 
 #[allow(clippy::too_many_lines)]
 fn bench_partial_json_incremental(c: &mut Criterion) {

--- a/crates/jsonmodem/benches/partial_json_strategies.rs
+++ b/crates/jsonmodem/benches/partial_json_strategies.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
+#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;

--- a/crates/jsonmodem/benches/partial_json_strategies.rs
+++ b/crates/jsonmodem/benches/partial_json_strategies.rs
@@ -1,5 +1,4 @@
 #![allow(missing_docs)]
-#![cfg(feature = "comparison")]
 
 mod partial_json_common;
 use std::time::Duration;
@@ -51,6 +50,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("fix_json_parse", parts),
             &parts,
@@ -62,6 +62,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             },
         );
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(BenchmarkId::new("jiter_partial", parts), &parts, |b, &p| {
             b.iter(|| {
                 let v = run_jiter_partial(black_box(&payload), p);
@@ -69,6 +70,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             });
         });
 
+        #[cfg(feature = "comparison")]
         group.bench_with_input(
             BenchmarkId::new("jiter_partial_owned", parts),
             &parts,

--- a/crates/jsonmodem/benches/partial_json_strategies.rs
+++ b/crates/jsonmodem/benches/partial_json_strategies.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use partial_json_common::{
-    make_json_payload, run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned,
-    run_parse_partial_json, run_streaming_parser, run_streaming_values_parser,
+    make_json_payload, run_parse_partial_json, run_streaming_parser, run_streaming_values_parser,
 };
+#[cfg(feature = "comparison")]
+use partial_json_common::{run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned};
 
 fn bench_partial_json_strategies(c: &mut Criterion) {
     let payload = make_json_payload(10_000);


### PR DESCRIPTION
## Summary
- gate competitive benchmarks behind new `comparison` feature
- document running benchmarks

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_687caf4cddc08320bd3f3b315e2f957b