### PR TITLE
Add flamegraph action

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -78,7 +78,7 @@ debug = "line-tables-only"
 
 ```bash
 RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bench partial_json_big
-sudo perf record -F 999 --call-graph dwarf ./target/release/streaming_parser
+sudo perf record -F 999 --call-graph dwarf ./target/release/partial_json_big
 sudo perf report -g fractal -F+srcline | head
 
 # Example output

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -86,6 +86,6 @@ sudo perf report -g fractal -F+srcline | head
 # 25.0% crates/jsonmodem/src/lexer.rs:87
 ```
 
-For deterministic instruction counts, `cargo profiler callgrind --release --bench streaming_parser` will emit
+For deterministic instruction counts, `cargo profiler callgrind --release --bench partial_json_big` will emit
 `callgrind.out.*` which can be viewed with `kcachegrind` and also prints the hottest lines directly in the
 terminal.

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -54,7 +54,7 @@ cargo bench --features comparison --bench partial_json_big -- --output-format be
 ## Flamegraphs and line-level profiling
 
 This repository ships a GitHub Action that runs
-`cargo flamegraph --bench partial_json_big` and uploads
+`cargo flamegraph --bench partial_json_big -- --bench` and uploads
 `flamegraph.svg`.  The `setup.sh` script installs `perf` so the same
 command can be run locally:
 
@@ -62,7 +62,7 @@ command can be run locally:
 cargo install flamegraph --locked
 sudo apt-get install -y linux-tools-common linux-tools-generic
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
-cargo flamegraph --package jsonmodem --bench partial_json_big
+cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
 # Finished release [optimized] target(s) in 0.23s
 # Flamegraph written to flamegraph.svg

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -54,7 +54,7 @@ cargo bench --features comparison --bench partial_json_big -- --output-format be
 ## Flamegraphs and line-level profiling
 
 This repository ships a GitHub Action that runs
-`cargo flamegraph --bench streaming_parser` and uploads
+`cargo flamegraph --bench partial_json_big` and uploads
 `flamegraph.svg`.  The `setup.sh` script installs `perf` so the same
 command can be run locally:
 

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -77,7 +77,7 @@ debug = "line-tables-only"
 ```
 
 ```bash
-RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bench streaming_parser
+RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bench partial_json_big
 sudo perf record -F 999 --call-graph dwarf ./target/release/streaming_parser
 sudo perf report -g fractal -F+srcline | head
 

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -62,7 +62,7 @@ command can be run locally:
 cargo install flamegraph --locked
 sudo apt-get install -y linux-tools-common linux-tools-generic
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
-cargo flamegraph --package jsonmodem --bench streaming_parser
+cargo flamegraph --package jsonmodem --bench partial_json_big
 
 # Finished release [optimized] target(s) in 0.23s
 # Flamegraph written to flamegraph.svg

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -50,3 +50,42 @@ cargo bench --bench partial_json_big -- --output-format bencher | rg '^test'
 # include external implementations
 cargo bench --features comparison --bench partial_json_big -- --output-format bencher | rg '^test'
 ```
+
+## Flamegraphs and line-level profiling
+
+This repository ships a GitHub Action that runs
+`cargo flamegraph --bench streaming_parser` and uploads
+`flamegraph.svg`.  The `setup.sh` script installs `perf` so the same
+command can be run locally:
+
+```bash
+cargo install flamegraph --locked
+sudo apt-get install -y linux-tools-common linux-tools-generic
+sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
+cargo flamegraph --package jsonmodem --bench streaming_parser
+
+# Finished release [optimized] target(s) in 0.23s
+# Flamegraph written to flamegraph.svg
+```
+
+To attribute samples to individual lines, compile with frame pointers and
+line-tables debug info and record with `perf`:
+
+```toml
+[profile.release]
+debug = "line-tables-only"
+```
+
+```bash
+RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bench streaming_parser
+sudo perf record -F 999 --call-graph dwarf ./target/release/streaming_parser
+sudo perf report -g fractal -F+srcline | head
+
+# Example output
+# 40.0% crates/jsonmodem/src/parser.rs:123
+# 25.0% crates/jsonmodem/src/lexer.rs:87
+```
+
+For deterministic instruction counts, `cargo profiler callgrind --release --bench streaming_parser` will emit
+`callgrind.out.*` which can be viewed with `kcachegrind` and also prints the hottest lines directly in the
+terminal.

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -26,4 +26,6 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 
 
 # Install perf for profiling
 sudo apt-get install -y linux-tools-common linux-tools-generic
-sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
+# Attempt to enable perf events for the current user. This can fail if
+# /proc/sys is read-only, such as in CI containers, so ignore errors.
+sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid' || true

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -23,3 +23,7 @@ sudo apt-get update
 sudo apt-get install -y clang-19 lldb-19 lld-19 llvm-19-dev
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+
+# Install perf for profiling
+sudo apt-get install -y linux-tools-common linux-tools-generic
+sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -27,7 +27,7 @@ jobs:
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench streaming_parser_big
+        run: cargo flamegraph --package jsonmodem --bench partial_json_big
 
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -27,7 +27,7 @@ jobs:
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench partial_json_big
+        run: cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -27,7 +27,7 @@ jobs:
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench streaming_parser
+        run: cargo flamegraph --package jsonmodem --bench streaming_parser_big
 
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -1,0 +1,36 @@
+name: Flamegraph
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  flamegraph:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo-flamegraph
+        run: cargo install flamegraph --locked
+
+      - name: Install perf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-tools-common linux-tools-generic
+          sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
+
+      - name: Generate flamegraph
+        run: cargo flamegraph --package jsonmodem --bench streaming_parser
+
+      - name: Upload flamegraph
+        uses: actions/upload-artifact@v4
+        with:
+          name: streaming-parser-flamegraph
+          path: flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,8 @@
 resolver = "3"
 members = ["crates/*", "fuzz"]
 
+[profile.release]
+debug = "line-tables-only"
+
 [profile.bench]
 debug = true

--- a/crates/jsonmodem/benches/competitive_benchmarks.rs
+++ b/crates/jsonmodem/benches/competitive_benchmarks.rs
@@ -297,7 +297,11 @@ struct Dataset {
 }
 
 fn bench_dataset(cfg: &Dataset, c: &mut Criterion) {
-    let path = format!("./benches/jiter_data/{}.json", cfg.name);
+    let path = format!(
+        "{}/benches/jiter_data/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        cfg.name
+    );
     let mut group = c.benchmark_group(cfg.name);
     group.measurement_time(Duration::from_secs(3));
     group.warm_up_time(Duration::from_secs(1));

--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -11,7 +11,11 @@ use partial_json_common::{
 };
 
 fn bench_partial_json_big(c: &mut Criterion) {
-    let payload = std::fs::read_to_string("./benches/jiter_data/medium_response.json").unwrap();
+    let payload = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/benches/jiter_data/medium_response.json"
+    ))
+    .unwrap();
 
     let mut group = c.benchmark_group("partial_json_big");
     group.measurement_time(Duration::from_secs(10));


### PR DESCRIPTION
## Summary
- add GitHub Action to run `cargo flamegraph` on the `streaming_parser` benchmark
- install `perf` in setup script for local and CI profiling
- document how to generate flamegraphs in `AGENTS.md`
- mention perf line-level profiling and Cargo.toml config

## Testing
- `./actionlint -color`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687cc55966e083208727d81da6641d5a