### PR TITLE
Fix flamegraph benchmark

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -54,7 +54,7 @@ cargo bench --features comparison --bench partial_json_big -- --output-format be
 ## Flamegraphs and line-level profiling
 
 This repository ships a GitHub Action that runs
-`cargo flamegraph --bench partial_json_big` and uploads
+`cargo flamegraph --bench partial_json_big -- --bench` and uploads
 `flamegraph.svg`.  The `setup.sh` script installs `perf` so the same
 command can be run locally:
 
@@ -62,7 +62,7 @@ command can be run locally:
 cargo install flamegraph --locked
 sudo apt-get install -y linux-tools-common linux-tools-generic
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
-cargo flamegraph --package jsonmodem --bench partial_json_big
+cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
 # Finished release [optimized] target(s) in 0.23s
 # Flamegraph written to flamegraph.svg

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -27,7 +27,7 @@ jobs:
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench partial_json_big
+        run: cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4

--- a/crates/jsonmodem/benches/competitive_benchmarks.rs
+++ b/crates/jsonmodem/benches/competitive_benchmarks.rs
@@ -297,7 +297,11 @@ struct Dataset {
 }
 
 fn bench_dataset(cfg: &Dataset, c: &mut Criterion) {
-    let path = format!("./benches/jiter_data/{}.json", cfg.name);
+    let path = format!(
+        "{}/benches/jiter_data/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        cfg.name
+    );
     let mut group = c.benchmark_group(cfg.name);
     group.measurement_time(Duration::from_secs(3));
     group.warm_up_time(Duration::from_secs(1));

--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -11,7 +11,11 @@ use partial_json_common::{
 };
 
 fn bench_partial_json_big(c: &mut Criterion) {
-    let payload = std::fs::read_to_string("./benches/jiter_data/medium_response.json").unwrap();
+    let payload = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/benches/jiter_data/medium_response.json"
+    ))
+    .unwrap();
 
     let mut group = c.benchmark_group("partial_json_big");
     group.measurement_time(Duration::from_secs(10));


### PR DESCRIPTION
## Summary
- fix file paths in `partial_json_big` and `competitive_benchmarks`
- update the flamegraph workflow to pass `-- --bench`
- document new command in `AGENTS.md`

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_6880435d76d88320958b8e7d2c333439