### PR TITLE
Fix setup script

### DIFF
--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -26,4 +26,6 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 
 
 # Install perf for profiling
 sudo apt-get install -y linux-tools-common linux-tools-generic
-sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
+# Attempt to enable perf events for the current user. This can fail if
+# /proc/sys is read-only, such as in CI containers, so ignore errors.
+sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid' || true


### PR DESCRIPTION
## Summary
- ignore failures to write to perf_event_paranoid

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_68804356c080832095357fdb50839832