### PR TITLE
Fix partial JSON prefix benchmarks

### DIFF
--- a/crates/jsonmodem/benches/partial_json_big.rs
+++ b/crates/jsonmodem/benches/partial_json_big.rs
@@ -4,7 +4,7 @@ mod partial_json_common;
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use jsonmodem::{produce_chunks, produce_prefixes};
+use jsonmodem::produce_chunks;
 #[cfg(feature = "comparison")]
 use partial_json_common::{run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned};
 use partial_json_common::{
@@ -24,7 +24,6 @@ fn bench_partial_json_big(c: &mut Criterion) {
 
     for &parts in &[100usize, 1_000, 5_000] {
         let chunks = produce_chunks(&payload, parts);
-        let prefixes = produce_prefixes(&payload, parts);
         group.bench_with_input(
             BenchmarkId::new("streaming_parser", parts),
             &parts,
@@ -52,7 +51,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_parse_partial_json(black_box(&prefixes));
+                    let v = run_parse_partial_json(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -64,7 +63,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_fix_json_parse(black_box(&prefixes));
+                    let v = run_fix_json_parse(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -76,7 +75,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_jiter_partial(black_box(&prefixes));
+                    let v = run_jiter_partial(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -88,7 +87,7 @@ fn bench_partial_json_big(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_jiter_partial_owned(black_box(&prefixes));
+                    let v = run_jiter_partial_owned(black_box(&chunks));
                     black_box(v);
                 });
             },

--- a/crates/jsonmodem/benches/partial_json_common.rs
+++ b/crates/jsonmodem/benches/partial_json_common.rs
@@ -56,11 +56,13 @@ pub fn run_streaming_values_parser(chunks: &[&str]) -> usize {
     produced + values.iter().filter(|v| v.is_final).count()
 }
 
-pub fn run_parse_partial_json(prefixes: &[&str]) -> usize {
-    let mut calls = 0;
+pub fn run_parse_partial_json(chunks: &[&str]) -> usize {
+    let mut calls = 0usize;
+    let mut prefix = String::new();
 
-    for &prefix in prefixes {
-        let _ = parse_partial_json_port::parse_partial_json(Some(prefix));
+    for &chunk in chunks {
+        prefix.push_str(chunk);
+        let _ = parse_partial_json_port::parse_partial_json(Some(&prefix));
         calls += 1;
     }
 
@@ -81,11 +83,13 @@ pub mod partial_json_fixer {
 }
 
 #[cfg(feature = "comparison")]
-pub fn run_fix_json_parse(prefixes: &[&str]) -> usize {
-    let mut calls = 0;
+pub fn run_fix_json_parse(chunks: &[&str]) -> usize {
+    let mut calls = 0usize;
+    let mut prefix = String::new();
 
-    for &prefix in prefixes {
-        let _ = partial_json_fixer::fix_json_parse(prefix);
+    for &chunk in chunks {
+        prefix.push_str(chunk);
+        let _ = partial_json_fixer::fix_json_parse(&prefix);
         calls += 1;
     }
 
@@ -93,11 +97,13 @@ pub fn run_fix_json_parse(prefixes: &[&str]) -> usize {
 }
 
 #[cfg(feature = "comparison")]
-pub fn run_jiter_partial(prefixes: &[&str]) -> usize {
+pub fn run_jiter_partial(chunks: &[&str]) -> usize {
     use jiter::{JsonValue, PartialMode};
     let mut calls = 0usize;
+    let mut prefix = String::new();
 
-    for &prefix in prefixes {
+    for &chunk in chunks {
+        prefix.push_str(chunk);
         let _ =
             JsonValue::parse_with_config(prefix.as_bytes(), false, PartialMode::TrailingStrings)
                 .unwrap();
@@ -108,11 +114,13 @@ pub fn run_jiter_partial(prefixes: &[&str]) -> usize {
 }
 
 #[cfg(feature = "comparison")]
-pub fn run_jiter_partial_owned(prefixes: &[&str]) -> usize {
+pub fn run_jiter_partial_owned(chunks: &[&str]) -> usize {
     use jiter::{JsonValue, PartialMode};
     let mut calls = 0usize;
+    let mut prefix = String::new();
 
-    for &prefix in prefixes {
+    for &chunk in chunks {
+        prefix.push_str(chunk);
         let _ =
             JsonValue::parse_with_config(prefix.as_bytes(), false, PartialMode::TrailingStrings)
                 .unwrap()

--- a/crates/jsonmodem/benches/partial_json_strategies.rs
+++ b/crates/jsonmodem/benches/partial_json_strategies.rs
@@ -4,7 +4,7 @@ mod partial_json_common;
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use jsonmodem::{produce_chunks, produce_prefixes};
+use jsonmodem::produce_chunks;
 use partial_json_common::{
     make_json_payload, run_parse_partial_json, run_streaming_parser, run_streaming_values_parser,
 };
@@ -20,7 +20,6 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
 
     for &parts in &[100usize, 1_000, 5_000] {
         let chunks = produce_chunks(&payload, parts);
-        let prefixes = produce_prefixes(&payload, parts);
         group.bench_with_input(
             BenchmarkId::new("streaming_parser", parts),
             &parts,
@@ -48,7 +47,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_parse_partial_json(black_box(&prefixes));
+                    let v = run_parse_partial_json(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -60,7 +59,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_fix_json_parse(black_box(&prefixes));
+                    let v = run_fix_json_parse(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -72,7 +71,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_jiter_partial(black_box(&prefixes));
+                    let v = run_jiter_partial(black_box(&chunks));
                     black_box(v);
                 });
             },
@@ -84,7 +83,7 @@ fn bench_partial_json_strategies(c: &mut Criterion) {
             &parts,
             |b, &_p| {
                 b.iter(|| {
-                    let v = run_jiter_partial_owned(black_box(&prefixes));
+                    let v = run_jiter_partial_owned(black_box(&chunks));
                     black_box(v);
                 });
             },


### PR DESCRIPTION
## Summary
- update `run_parse_partial_json` and comparison helpers to build a prefix string incrementally
- adjust the partial JSON benchmarks to pass chunk slices to these helpers

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_688098efea388320aa76acf48b5a9411