### PR TITLE
Improve streaming parser value zipper performance

### DIFF
--- a/crates/jsonmodem/src/value_zipper.rs
+++ b/crates/jsonmodem/src/value_zipper.rs
@@ -234,8 +234,8 @@ impl ValueZipper {
                 // `initializer` and once for the caller-supplied closure.
                 let cloned_default = default.clone();
                 arr.push(initializer(default));
-                let len = arr.len();
-                f(cloned_default, Some(&mut arr[len - 1]))?;
+                let last = arr.last_mut().expect("just pushed");
+                f(cloned_default, Some(last))?;
             }
             Ordering::Greater => return Err(ZipperError::InvalidArrayIndex),
         }
@@ -281,7 +281,7 @@ impl ValueZipper {
                 Ordering::Less => NonNull::from(&mut arr[index]),
                 Ordering::Equal => {
                     arr.push(make_child());
-                    NonNull::from(&mut arr[index])
+                    NonNull::from(arr.last_mut().expect("just pushed"))
                 }
                 Ordering::Greater => return Err(ZipperError::InvalidArrayIndex),
             }


### PR DESCRIPTION
## Summary
- tweak ValueZipper array insertion logic to reuse last element

## Testing
- `cargo build --all --release --workspace --quiet`
- `cargo test --all --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)`
- `./actionlint -color`
- `cargo bench --bench partial_json_big -- streaming_values_parser/100`
- `cargo bench --bench partial_json_big -- streaming_values_parser/1000`
- `cargo bench --bench partial_json_big streaming_values_parser/5000 -- --output-format bencher`

------
https://chatgpt.com/codex/tasks/task_e_6881cb9a2a7c8320921a8072846ca8c7