### PR TITLE
Fix line profiling command

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -60,7 +60,8 @@ command can be run locally:
 
 ```bash
 cargo install flamegraph --locked
-sudo apt-get install -y linux-tools-common linux-tools-generic
+sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" || \
+  sudo apt-get install -y linux-tools-generic
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
@@ -77,13 +78,40 @@ debug = "line-tables-only"
 ```
 
 ```bash
-RUSTFLAGS="-C force-frame-pointers=yes" cargo build --release --bench partial_json_big
-sudo perf record -F 999 --call-graph dwarf ./target/release/partial_json_big
-sudo perf report -g fractal -F+srcline | head
+RUSTFLAGS="-C force-frame-pointers=yes" \
+  cargo bench --bench partial_json_big --no-run
+BIN=$(find target/release/deps -maxdepth 1 -executable -name 'partial_json_big-*' | head -n 1)
+# Locate the perf binary in case the wrapper doesn't match the running kernel
+PERF_BIN=$(command -v perf || true)
+if [ ! -x "$PERF_BIN" ]; then
+  PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
+fi
+# Record samples into perf.data while suppressing progress output
+sudo "$PERF_BIN" record -F 999 --call-graph dwarf -o perf.data -- "$BIN" --bench >/dev/null 2>&1
+# Generate a report showing file and line numbers
+"$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
+# Extract the hottest lines with surrounding code
+python3 scripts/perf_snippet.py perf_report.txt | tee perf_snippet.log
+
+The helper script reads `perf_report.txt`, extracts the hottest lines,
+and prints them with short code snippets. Redirect the output if you
+want to save it:
+
+```bash
+python3 scripts/perf_snippet.py | tee perf_with_code.txt
+```
 
 # Example output
-# 40.0% crates/jsonmodem/src/parser.rs:123
-# 25.0% crates/jsonmodem/src/lexer.rs:87
+```text
+40.0% crates/jsonmodem/src/parser.rs:123
+   122:     StringEscapeUnicode,
+   123:     BeforePropertyName,
+   124:     AfterPropertyName,
+
+25.0% crates/jsonmodem/src/event.rs:87
+    86:     };
+    87: }
+    88:
 ```
 
 For deterministic instruction counts, `cargo profiler callgrind --release --bench partial_json_big` will emit

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -24,8 +24,10 @@ sudo apt-get install -y clang-19 lldb-19 lld-19 llvm-19-dev
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
 
-# Install perf for profiling
-sudo apt-get install -y linux-tools-common linux-tools-generic
+# Install perf for profiling. Prefer the tools matching the current kernel and
+# fall back to the generic package when unavailable.
+sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" \
+  || sudo apt-get install -y linux-tools-generic
 # Attempt to enable perf events for the current user. This can fail if
 # /proc/sys is read-only, such as in CI containers, so ignore errors.
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid' || true

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -23,14 +23,37 @@ jobs:
       - name: Install perf
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-tools-common linux-tools-generic
+          sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" || \
+            sudo apt-get install -y linux-tools-generic
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
         run: cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
 
+      - name: Collect line-level perf information
+        run: |
+          set -euo pipefail
+          # Build the benchmark with frame pointers enabled but don't run it yet
+          RUSTFLAGS="-C force-frame-pointers=yes" \
+            cargo bench --bench partial_json_big --no-run
+          BIN=$(find target/release/deps -maxdepth 1 -executable -name 'partial_json_big-*' | head -n 1)
+          # Locate the perf binary even if /usr/bin/perf is missing for this kernel
+          PERF_BIN=$(command -v perf || true)
+          if [ ! -x "$PERF_BIN" ]; then
+            PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
+          fi
+          # Record samples into perf.data while suppressing progress output
+          sudo "$PERF_BIN" record -F 999 --call-graph dwarf -o perf.data -- "$BIN" --bench >/dev/null 2>&1
+          # Generate a text report with file and line numbers
+          "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
+          # Extract the hottest lines and print small code snippets
+          python3 scripts/perf_snippet.py perf_report.txt | tee perf_with_code.txt
+
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4
         with:
           name: streaming-parser-flamegraph
-          path: flamegraph.svg
+          path: |
+            flamegraph.svg
+            perf_report.txt
+            perf_with_code.txt

--- a/scripts/perf_snippet.py
+++ b/scripts/perf_snippet.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Extract hot lines from a perf report and print surrounding code.
+
+The script prints results to stdout. Redirect or pipe the output as needed."""
+
+from __future__ import annotations
+
+import linecache
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    report_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("perf_report.txt")
+    max_entries = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+    pattern = re.compile(r"(\d+\.\d+%)\s+.*\s+([^\s:]+\.rs):(\d+)")
+    entries: list[tuple[str, Path, int]] = []
+
+    with report_path.open() as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                pct, file, line_no = m.group(1), Path(m.group(2)), int(m.group(3))
+                entries.append((pct, file, line_no))
+                if len(entries) >= max_entries:
+                    break
+
+    for pct, file, line_no in entries:
+        print(f"{pct} {file}:{line_no}")
+        for i in range(line_no - 1, line_no + 2):
+            if i <= 0:
+                continue
+            text = linecache.getline(str(file), i)
+            if text:
+                print(f"{i:6}: {text}", end="")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- improve perf binary detection in flamegraph workflow
- update documentation for locating perf
- redirect perf output to files

## Testing
- `cargo build --all --release --workspace --quiet`
- `cargo test --all --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`

------
https://chatgpt.com/codex/tasks/task_e_68805babaf6083208fb3b14e9d09ab0a