### PR TITLE
Update profiling docs and workflow

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -91,8 +91,9 @@ PERF_BIN=$(command -v perf || true)
 if [ ! -x "$PERF_BIN" ]; then
   PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
 fi
-# Record samples into perf.data while suppressing progress output
-sudo "$PERF_BIN" record -F 999 --call-graph dwarf -o perf.data -- "$BIN" --bench >/dev/null 2>&1
+# Record a short run of the parse_partial_json benchmark to keep the report small
+sudo "$PERF_BIN" record -F 200 --call-graph fp -o perf.data -- \
+  "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1 >/dev/null 2>&1
 # Generate a report showing file and line numbers
 "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
 # Extract the hottest lines with surrounding code

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -97,6 +97,8 @@ echo "Using $PERF_BIN"
 # Record a short run of the parse_partial_json benchmark to keep the report small
 sudo "$PERF_BIN" record -F 200 --call-graph fp -o perf.data -- \
   "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1 >/dev/null 2>&1
+# Change ownership so perf_report can read the file
+sudo chown "$(id -u):$(id -g)" perf.data
 # Generate a report showing file and line numbers
 "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
 # Extract the hottest lines with surrounding code

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -50,16 +50,16 @@ cargo bench --bench streaming_parser -- --output-format bencher | rg '^test'
 # test streaming_parser_split/5000 ... bench:  604477 ns/iter (+/- 8785)
 
 # partial JSON benchmarks
-cargo bench --bench partial_json_big -- --output-format bencher | rg '^test'
+cargo bench --bench streaming_json_medium -- --output-format bencher | rg '^test'
 
 # include external implementations
-cargo bench --features comparison --bench partial_json_big -- --output-format bencher | rg '^test'
+cargo bench --features comparison --bench streaming_json_medium -- --output-format bencher | rg '^test'
 ```
 
 ## Flamegraphs and line-level profiling
 
 This repository ships a GitHub Action that runs
-`cargo flamegraph --bench partial_json_big -- --bench` and uploads
+`cargo flamegraph --bench streaming_json_medium -- --bench` and uploads
 `flamegraph.svg`.  The `setup.sh` script installs `perf` so the same
 command can be run locally:
 
@@ -68,7 +68,7 @@ cargo install flamegraph --locked
 sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" || \
   sudo apt-get install -y linux-tools-generic
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
-cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
+cargo flamegraph --package jsonmodem --bench streaming_json_medium -- --bench
 
 # Finished release [optimized] target(s) in 0.23s
 # Flamegraph written to flamegraph.svg
@@ -84,8 +84,8 @@ debug = "line-tables-only"
 
 ```bash
 RUSTFLAGS="-C force-frame-pointers=yes" \
-  cargo bench --bench partial_json_big --no-run
-BIN=$(find target/release/deps -maxdepth 1 -executable -name 'partial_json_big-*' | head -n 1)
+  cargo bench --bench streaming_json_medium --no-run
+BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_medium-*' | head -n 1)
 # Locate the perf binary in case the wrapper doesn't match the running kernel
 PERF_BIN=$(command -v perf || true)
 if [ ! -x "$PERF_BIN" ]; then
@@ -113,12 +113,12 @@ python3 scripts/perf_snippet.py | tee perf_with_code.txt
    123:     BeforePropertyName,
    124:     AfterPropertyName,
 
-25.0% crates/jsonmodem/src/event.rs:87
+25.0% crates/jsonmodem/src/lexer.rs:87
     86:     };
     87: }
     88:
 ```
 
-For deterministic instruction counts, `cargo profiler callgrind --release --bench partial_json_big` will emit
+For deterministic instruction counts, `cargo profiler callgrind --release --bench streaming_json_medium` will emit
 `callgrind.out.*` which can be viewed with `kcachegrind` and also prints the hottest lines directly in the
 terminal.

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 # Install stable Rust toolchain matching CI
 rustup toolchain install 1.87.0 || true

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -24,8 +24,10 @@ sudo apt-get install -y clang-19 lldb-19 lld-19 llvm-19-dev
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
 
-# Install perf for profiling
-sudo apt-get install -y linux-tools-common linux-tools-generic
+# Install perf for profiling. Prefer the tools matching the current kernel and
+# fall back to the generic package when unavailable.
+sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" \
+  || sudo apt-get install -y linux-tools-generic
 # Attempt to enable perf events for the current user. This can fail if
 # /proc/sys is read-only, such as in CI containers, so ignore errors.
 sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid' || true

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -32,21 +32,23 @@ jobs:
 
       - name: Collect line-level perf information
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           # Build the benchmark with frame pointers enabled but don't run it yet
           RUSTFLAGS="-C force-frame-pointers=yes" \
             cargo bench --bench streaming_json_medium --no-run
           BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_medium-*' | head -n 1)
-          # Locate the perf binary even if /usr/bin/perf is missing for this kernel
-          PERF_BIN=$(command -v perf || true)
-          if [ ! -x "$PERF_BIN" ]; then
-            PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
+          echo "Benchmark binary: $BIN"
+          # Locate a usable perf binary. The wrapper at /usr/bin/perf often fails
+          PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
+          if [ -z "$PERF_BIN" ]; then
+            PERF_BIN=$(command -v perf)
           fi
+          echo "Using perf from $PERF_BIN"
           # Record a short parse_partial_json run to keep the report small
           sudo "$PERF_BIN" record -F 200 --call-graph fp -o perf.data -- \
-            "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1 >/dev/null 2>&1
+            "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1
           # Generate a text report with file and line numbers
-          "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
+          "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt
           # Extract the hottest lines and print small code snippets
           python3 scripts/perf_snippet.py perf_report.txt | tee perf_with_code.txt
 

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -23,14 +23,37 @@ jobs:
       - name: Install perf
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-tools-common linux-tools-generic
+          sudo apt-get install -y linux-tools-common "linux-tools-$(uname -r)" || \
+            sudo apt-get install -y linux-tools-generic
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench streaming_json_medium -- --bench
+        run: cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
+
+      - name: Collect line-level perf information
+        run: |
+          set -euo pipefail
+          # Build the benchmark with frame pointers enabled but don't run it yet
+          RUSTFLAGS="-C force-frame-pointers=yes" \
+            cargo bench --bench partial_json_big --no-run
+          BIN=$(find target/release/deps -maxdepth 1 -executable -name 'partial_json_big-*' | head -n 1)
+          # Locate the perf binary even if /usr/bin/perf is missing for this kernel
+          PERF_BIN=$(command -v perf || true)
+          if [ ! -x "$PERF_BIN" ]; then
+            PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
+          fi
+          # Record samples into perf.data while suppressing progress output
+          sudo "$PERF_BIN" record -F 999 --call-graph dwarf -o perf.data -- "$BIN" --bench >/dev/null 2>&1
+          # Generate a text report with file and line numbers
+          "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
+          # Extract the hottest lines and print small code snippets
+          python3 scripts/perf_snippet.py perf_report.txt | tee perf_with_code.txt
 
       - name: Upload flamegraph
         uses: actions/upload-artifact@v4
         with:
           name: streaming-parser-flamegraph
-          path: flamegraph.svg
+          path: |
+            flamegraph.svg
+            perf_report.txt
+            perf_with_code.txt

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -28,15 +28,15 @@ jobs:
           sudo bash -c 'echo 0 > /proc/sys/kernel/perf_event_paranoid'
 
       - name: Generate flamegraph
-        run: cargo flamegraph --package jsonmodem --bench partial_json_big -- --bench
+        run: cargo flamegraph --package jsonmodem --bench streaming_json_medium -- --bench
 
       - name: Collect line-level perf information
         run: |
           set -euo pipefail
           # Build the benchmark with frame pointers enabled but don't run it yet
           RUSTFLAGS="-C force-frame-pointers=yes" \
-            cargo bench --bench partial_json_big --no-run
-          BIN=$(find target/release/deps -maxdepth 1 -executable -name 'partial_json_big-*' | head -n 1)
+            cargo bench --bench streaming_json_medium --no-run
+          BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_medium-*' | head -n 1)
           # Locate the perf binary even if /usr/bin/perf is missing for this kernel
           PERF_BIN=$(command -v perf || true)
           if [ ! -x "$PERF_BIN" ]; then

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -47,6 +47,7 @@ jobs:
           # Record a short parse_partial_json run to keep the report small
           sudo "$PERF_BIN" record -F 200 --call-graph fp -o perf.data -- \
             "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1
+          sudo chown "$(id -u):$(id -g)" perf.data
           # Generate a text report with file and line numbers
           "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt
           # Extract the hottest lines and print small code snippets

--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -42,8 +42,9 @@ jobs:
           if [ ! -x "$PERF_BIN" ]; then
             PERF_BIN=$(find /usr/lib/linux-tools* -maxdepth 2 -name perf | sort -V | tail -n 1)
           fi
-          # Record samples into perf.data while suppressing progress output
-          sudo "$PERF_BIN" record -F 999 --call-graph dwarf -o perf.data -- "$BIN" --bench >/dev/null 2>&1
+          # Record a short parse_partial_json run to keep the report small
+          sudo "$PERF_BIN" record -F 200 --call-graph fp -o perf.data -- \
+            "$BIN" --bench parse_partial_json --sample-size 10 --measurement-time 1 >/dev/null 2>&1
           # Generate a text report with file and line numbers
           "$PERF_BIN" report -i perf.data -g fractal -F+srcline --stdio > perf_report.txt 2>&1
           # Extract the hottest lines and print small code snippets

--- a/scripts/perf_snippet.py
+++ b/scripts/perf_snippet.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Extract hot lines from a perf report and print surrounding code.
+
+The script prints results to stdout. Redirect or pipe the output as needed."""
+
+from __future__ import annotations
+
+import linecache
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    report_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("perf_report.txt")
+    max_entries = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+    pattern = re.compile(r"(\d+\.\d+%)\s+.*\s+([^\s:]+\.rs):(\d+)")
+    entries: list[tuple[str, Path, int]] = []
+
+    with report_path.open() as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                pct, file, line_no = m.group(1), Path(m.group(2)), int(m.group(3))
+                entries.append((pct, file, line_no))
+                if len(entries) >= max_entries:
+                    break
+
+    for pct, file, line_no in entries:
+        print(f"{pct} {file}:{line_no}")
+        for i in range(line_no - 1, line_no + 2):
+            if i <= 0:
+                continue
+            text = linecache.getline(str(file), i)
+            if text:
+                print(f"{i:6}: {text}", end="")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how to profile with perf and code snippets
- install kernel-specific perf in setup scripts and CI
- upload line-level perf report in flamegraph workflow
- add helper `perf_snippet.py` script

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`


------
https://chatgpt.com/codex/tasks/task_e_6882bd2916c48320835839b1b4f78b29