### PR TITLE
Optimize Buffer::copy_while

### DIFF
--- a/crates/jsonmodem/src/buffer.rs
+++ b/crates/jsonmodem/src/buffer.rs
@@ -30,22 +30,34 @@ impl Buffer {
         self.data.pop_front()
     }
 
+    #[inline]
     pub(crate) fn copy_while<F>(&mut self, dst: &mut String, mut predicate: F) -> usize
     where
         F: FnMut(char) -> bool,
     {
         let mut copied = 0;
         loop {
-            let (front, _) = self.data.as_slices();
-            if front.is_empty() {
-                break;
-            }
+            let (front_len, prefix) = {
+                let (front, _) = self.data.as_slices();
+                if front.is_empty() {
+                    break;
+                }
 
-            let front_len = front.len();
-            let prefix = front.iter().take_while(|&&ch| predicate(ch)).count();
-            if prefix == 0 {
-                break;
-            }
+                let mut prefix = 0;
+                for &ch in front {
+                    if predicate(ch) {
+                        prefix += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                if prefix == 0 {
+                    break;
+                }
+
+                (front.len(), prefix)
+            };
 
             dst.extend(self.data.drain(..prefix));
             copied += prefix;


### PR DESCRIPTION
## Summary
- micro-optimize `Buffer::copy_while` to reduce iterator overhead
- run repo checks

## Testing
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --all --workspace --all-features --verbose`
- `cargo build --all --release --workspace`
- `./actionlint -color`
- `cargo bench --bench streaming_parser -- --output-format bencher | rg '^test'`

------
https://chatgpt.com/codex/tasks/task_e_6882edd3bd0c832087c6663afa9a7bb6