### PR TITLE
refactor: clarify clippy lint usage

### DIFF
--- a/crates/jsonmodem/benches/competitive_benchmarks.rs
+++ b/crates/jsonmodem/benches/competitive_benchmarks.rs
@@ -1,5 +1,5 @@
-#![allow(missing_docs)]
 #![cfg(feature = "comparison")]
+#![allow(missing_docs)]
 //! Benchmark comparison of jiter, `serde_json`, and jsonmodem
 //!
 //! ```text
@@ -109,23 +109,22 @@ fn jiter_iter_big(path: &str, group: &mut BenchmarkGroup<'_, WallTime>) {
     });
 }
 
+fn find_string(jiter: &mut Jiter) -> String {
+    match jiter.peek().unwrap() {
+        Peek::String => jiter.known_str().unwrap().to_string(),
+        Peek::Array => {
+            assert!(jiter.known_array().unwrap().is_some());
+            let s = find_string(jiter).to_string();
+            assert!(jiter.array_step().unwrap().is_none());
+            s
+        }
+        _ => panic!("Expected string or array"),
+    }
+}
+
 fn jiter_iter_pass2(path: &str, group: &mut BenchmarkGroup<'_, WallTime>) {
     let json = read_file(path);
     let json_data = black_box(json.as_bytes());
-
-    #[allow(clippy::items_after_statements)]
-    fn find_string(jiter: &mut Jiter) -> String {
-        match jiter.peek().unwrap() {
-            Peek::String => jiter.known_str().unwrap().to_string(),
-            Peek::Array => {
-                assert!(jiter.known_array().unwrap().is_some());
-                let s = find_string(jiter).to_string();
-                assert!(jiter.array_step().unwrap().is_none());
-                s
-            }
-            _ => panic!("Expected string or array"),
-        }
-    }
 
     group.bench_function("jiter_iter", |b| {
         b.iter(|| {

--- a/crates/jsonmodem/benches/parse_partial_json_port.rs
+++ b/crates/jsonmodem/benches/parse_partial_json_port.rs
@@ -404,26 +404,24 @@ pub fn fix_json(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
-    use super::*;
 
     #[test]
     fn test_fix_json_simple_string() {
         let inp = "\"hello"; // missing closing quote
-        let fixed = fix_json(inp);
+        let fixed = super::fix_json(inp);
         assert_eq!(fixed, "\"hello\"");
     }
 
     #[test]
     fn test_parse_partial_json_success() {
-        let (val, state) = parse_partial_json(Some("123"));
+        let (val, state) = super::parse_partial_json(Some("123"));
         assert_eq!(state, ParseState::SuccessfulParse);
         assert_eq!(val.unwrap(), serde_json::json!(123));
     }
 
     #[test]
     fn test_parse_partial_json_repaired() {
-        let (val, state) = parse_partial_json(Some("[1, 2, 3")); // missing ]
+        let (val, state) = super::parse_partial_json(Some("[1, 2, 3")); // missing ]
         assert_eq!(state, ParseState::RepairedParse);
         assert_eq!(val.unwrap(), serde_json::json!([1, 2, 3]));
     }
@@ -434,14 +432,14 @@ mod tests {
         // down to its last *syntactically* valid prefix which, in this case,
         // is just the opening brace – completed to `{}` during the
         // post-processing phase. Therefore the parse **succeeds after repair**.
-        let (val, state) = parse_partial_json(Some("{ invalid json"));
+        let (val, state) = super::parse_partial_json(Some("{ invalid json"));
         assert_eq!(state, ParseState::RepairedParse);
         assert_eq!(val.unwrap(), serde_json::json!({}));
     }
     #[test]
     fn unicode_inside_unterminated_string() {
         let inp = r#"{"msg":"¡Hola"#;
-        let (val, state) = parse_partial_json(Some(inp));
+        let (val, state) = super::parse_partial_json(Some(inp));
         assert_eq!(state, ParseState::RepairedParse);
         assert_eq!(val.unwrap()["msg"], "¡Hola");
     }
@@ -449,7 +447,7 @@ mod tests {
     #[test]
     fn ignore_trailing_garbage_after_complete_value() {
         let inp = "123abc";
-        let (val, state) = parse_partial_json(Some(inp));
+        let (val, state) = super::parse_partial_json(Some(inp));
         // TS version succeeds; Rust should too once patched.
         assert_eq!(state, ParseState::RepairedParse);
         assert_eq!(val.unwrap(), serde_json::json!(123));

--- a/crates/jsonmodem/benches/streaming_json_common.rs
+++ b/crates/jsonmodem/benches/streaming_json_common.rs
@@ -1,6 +1,3 @@
-#![allow(missing_docs)]
-#![allow(dead_code)]
-
 #[path = "parse_partial_json_port.rs"]
 pub mod parse_partial_json_port;
 use jsonmodem::{
@@ -8,6 +5,7 @@ use jsonmodem::{
 };
 
 /// Deterministically create a JSON document of exactly `target_len` bytes.
+#[allow(dead_code)]
 pub fn make_json_payload(target_len: usize) -> String {
     let overhead = "{\"data\":\"\"}".len();
     assert!(target_len >= overhead);
@@ -20,6 +18,7 @@ pub fn make_json_payload(target_len: usize) -> String {
     s
 }
 
+#[allow(dead_code)]
 pub fn run_streaming_parser(chunks: &[&str], mode: NonScalarValueMode) -> usize {
     let mut parser = StreamingParser::new(ParserOptions {
         non_scalar_values: mode,
@@ -42,6 +41,7 @@ pub fn run_streaming_parser(chunks: &[&str], mode: NonScalarValueMode) -> usize 
     events
 }
 
+#[allow(dead_code)]
 pub fn run_streaming_values_parser(chunks: &[&str]) -> usize {
     let mut parser = StreamingValuesParser::new(ParserOptions {
         non_scalar_values: NonScalarValueMode::Roots,
@@ -59,6 +59,7 @@ pub fn run_streaming_values_parser(chunks: &[&str]) -> usize {
     produced + values.iter().filter(|v| v.is_final).count()
 }
 
+#[allow(dead_code)]
 pub fn run_parse_partial_json(chunks: &[&str]) -> usize {
     let mut calls = 0usize;
     let mut prefix = String::new();
@@ -86,6 +87,7 @@ pub mod partial_json_fixer {
 }
 
 #[cfg(feature = "comparison")]
+#[allow(dead_code)]
 pub fn run_fix_json_parse(chunks: &[&str]) -> usize {
     let mut calls = 0usize;
     let mut prefix = String::new();
@@ -100,6 +102,7 @@ pub fn run_fix_json_parse(chunks: &[&str]) -> usize {
 }
 
 #[cfg(feature = "comparison")]
+#[allow(dead_code)]
 pub fn run_jiter_partial(chunks: &[&str]) -> usize {
     use jiter::{JsonValue, PartialMode};
     let mut calls = 0usize;
@@ -117,6 +120,7 @@ pub fn run_jiter_partial(chunks: &[&str]) -> usize {
 }
 
 #[cfg(feature = "comparison")]
+#[allow(dead_code)]
 pub fn run_jiter_partial_owned(chunks: &[&str]) -> usize {
     use jiter::{JsonValue, PartialMode};
     let mut calls = 0usize;

--- a/crates/jsonmodem/benches/streaming_json_incremental.rs
+++ b/crates/jsonmodem/benches/streaming_json_incremental.rs
@@ -1,5 +1,5 @@
+//! Benchmarks for incremental streaming scenarios.
 #![allow(missing_docs)]
-
 mod streaming_json_common;
 use std::time::Duration;
 

--- a/crates/jsonmodem/benches/streaming_json_large.rs
+++ b/crates/jsonmodem/benches/streaming_json_large.rs
@@ -1,5 +1,5 @@
+//! Benchmarks for streaming large JSON payloads.
 #![allow(missing_docs)]
-
 mod streaming_json_common;
 use std::time::Duration;
 

--- a/crates/jsonmodem/benches/streaming_json_medium.rs
+++ b/crates/jsonmodem/benches/streaming_json_medium.rs
@@ -1,5 +1,5 @@
+//! Benchmarks for streaming medium-sized JSON inputs.
 #![allow(missing_docs)]
-
 mod streaming_json_common;
 use std::time::Duration;
 

--- a/crates/jsonmodem/benches/streaming_json_strategies.rs
+++ b/crates/jsonmodem/benches/streaming_json_strategies.rs
@@ -1,5 +1,5 @@
+//! Benchmarks comparing streaming strategies.
 #![allow(missing_docs)]
-
 mod streaming_json_common;
 use std::time::Duration;
 

--- a/crates/jsonmodem/benches/streaming_parser.rs
+++ b/crates/jsonmodem/benches/streaming_parser.rs
@@ -1,5 +1,5 @@
-#![allow(missing_docs)]
 //! Benchmark – `jsonmodem::StreamingParser`
+#![allow(missing_docs)]
 
 use std::time::Duration;
 

--- a/crates/jsonmodem/src/chunk_utils.rs
+++ b/crates/jsonmodem/src/chunk_utils.rs
@@ -2,8 +2,11 @@ use alloc::vec::Vec;
 
 /// Split `payload` into approximately equal-sized chunks without
 /// breaking UTF-8 code points.
+///
+/// # Panics
+///
+/// Panics if `parts` is zero.
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn produce_chunks(payload: &str, parts: usize) -> Vec<&str> {
     assert!(parts > 0);
     let len = payload.len();
@@ -22,8 +25,11 @@ pub fn produce_chunks(payload: &str, parts: usize) -> Vec<&str> {
 }
 
 /// Return a sequence of prefixes converging to `payload`.
+///
+/// # Panics
+///
+/// Panics if `parts` is zero.
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
 pub fn produce_prefixes(payload: &str, parts: usize) -> Vec<&str> {
     let chunks = produce_chunks(payload, parts);
     let mut prefixes = Vec::with_capacity(chunks.len());

--- a/crates/jsonmodem/src/event_stack.rs
+++ b/crates/jsonmodem/src/event_stack.rs
@@ -33,28 +33,28 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
                 ParseEvent::Null { path } => {
                     let v = {
                         let f = builder.factory();
-                        f.into_any_null(f.new_null())
+                        f.any_from_null(f.new_null())
                     };
                     builder.set(path.last(), v)?;
                 }
                 ParseEvent::Boolean { path, value } => {
                     let v = {
                         let f = builder.factory();
-                        f.into_any_bool(f.new_bool(*value))
+                        f.any_from_bool(f.new_bool(*value))
                     };
                     builder.set(path.last(), v)?;
                 }
                 ParseEvent::Number { path, value } => {
                     let v = {
                         let f = builder.factory();
-                        f.into_any_num(f.new_number(*value))
+                        f.any_from_num(f.new_number(*value))
                     };
                     builder.set(path.last(), v)?;
                 }
                 ParseEvent::String { fragment, path, .. } => {
                     let init = {
                         let f = builder.factory();
-                        f.into_any_str(f.new_string(""))
+                        f.any_from_str(f.new_string(""))
                     };
                     builder.mutate_with(
                         path.last(),
@@ -74,14 +74,14 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
                 ParseEvent::ObjectBegin { path } => {
                     let init = {
                         let f = builder.factory();
-                        f.into_any_object(f.new_object())
+                        f.any_from_object(f.new_object())
                     };
                     builder.enter_with(path.last(), || init)?;
                 }
                 ParseEvent::ArrayStart { path } => {
                     let init = {
                         let f = builder.factory();
-                        f.into_any_array(f.new_array())
+                        f.any_from_array(f.new_array())
                     };
                     builder.enter_with(path.last(), || init)?;
                 }

--- a/crates/jsonmodem/src/factory.rs
+++ b/crates/jsonmodem/src/factory.rs
@@ -5,7 +5,6 @@ use alloc::{borrow::ToOwned, collections::BTreeMap, string::String, vec::Vec};
 use crate::value::Value;
 
 /// Abstraction over JSON value construction.
-#[allow(clippy::wrong_self_convention)]
 pub trait JsonFactory {
     type Str;
     type Num;
@@ -25,12 +24,12 @@ pub trait JsonFactory {
     fn push_array(&self, array: &mut Self::Array, val: Self::Any);
     fn insert_object(&self, obj: &mut Self::Object, key: &str, val: Self::Any);
 
-    fn into_any_str(&self, s: Self::Str) -> Self::Any;
-    fn into_any_num(&self, n: Self::Num) -> Self::Any;
-    fn into_any_bool(&self, b: Self::Bool) -> Self::Any;
-    fn into_any_null(&self, n: Self::Null) -> Self::Any;
-    fn into_any_array(&self, a: Self::Array) -> Self::Any;
-    fn into_any_object(&self, o: Self::Object) -> Self::Any;
+    fn any_from_str(&self, s: Self::Str) -> Self::Any;
+    fn any_from_num(&self, n: Self::Num) -> Self::Any;
+    fn any_from_bool(&self, b: Self::Bool) -> Self::Any;
+    fn any_from_null(&self, n: Self::Null) -> Self::Any;
+    fn any_from_array(&self, a: Self::Array) -> Self::Any;
+    fn any_from_object(&self, o: Self::Object) -> Self::Any;
 }
 
 /// Factory producing standard Rust values.
@@ -87,32 +86,32 @@ impl JsonFactory for StdFactory {
     }
 
     #[inline(always)]
-    fn into_any_str(&self, s: Self::Str) -> Self::Any {
+    fn any_from_str(&self, s: Self::Str) -> Self::Any {
         Value::String(s)
     }
 
     #[inline(always)]
-    fn into_any_num(&self, n: Self::Num) -> Self::Any {
+    fn any_from_num(&self, n: Self::Num) -> Self::Any {
         Value::Number(n)
     }
 
     #[inline(always)]
-    fn into_any_bool(&self, b: Self::Bool) -> Self::Any {
+    fn any_from_bool(&self, b: Self::Bool) -> Self::Any {
         Value::Boolean(b)
     }
 
     #[inline(always)]
-    fn into_any_null(&self, _n: Self::Null) -> Self::Any {
+    fn any_from_null(&self, _n: Self::Null) -> Self::Any {
         Value::Null
     }
 
     #[inline(always)]
-    fn into_any_array(&self, a: Self::Array) -> Self::Any {
+    fn any_from_array(&self, a: Self::Array) -> Self::Any {
         Value::Array(a)
     }
 
     #[inline(always)]
-    fn into_any_object(&self, o: Self::Object) -> Self::Any {
+    fn any_from_object(&self, o: Self::Object) -> Self::Any {
         Value::Object(o)
     }
 }

--- a/crates/jsonmodem/src/value_zipper.rs
+++ b/crates/jsonmodem/src/value_zipper.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::enum_glob_use)]
-
 use alloc::{boxed::Box, collections::btree_map::Entry, string::String, vec::Vec};
 use core::{cmp::Ordering, ptr::NonNull};
 
@@ -309,19 +307,18 @@ pub enum ZipperError {
 
 impl core::fmt::Display for ZipperError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use ZipperError::*;
         write!(
             f,
             "{}",
             match self {
-                ExpectedObject => "expected an object at the current path",
-                ExpectedArray => "expected an array at the current path",
-                InvalidArrayIndex => "invalid array index",
-                ExpectedEmptyPath => "operation requires an empty path",
-                ExpectedNonEmptyPath => "operation would pop past the root",
-                ExpectedString => "expected the root to be a string",
+                Self::ExpectedObject => "expected an object at the current path",
+                Self::ExpectedArray => "expected an array at the current path",
+                Self::InvalidArrayIndex => "invalid array index",
+                Self::ExpectedEmptyPath => "operation requires an empty path",
+                Self::ExpectedNonEmptyPath => "operation would pop past the root",
+                Self::ExpectedString => "expected the root to be a string",
                 #[cfg(test)]
-                ParserError => "parser error occurred",
+                Self::ParserError => "parser error occurred",
             }
         )
     }
@@ -354,15 +351,9 @@ impl<F: crate::factory::JsonFactory<Any = Value> + Default> Default for ValueBui
 }
 
 macro_rules! raise {
-    ($err:expr) => {{
-        #[cfg(test)]
-        {
-            panic!("ZipperError: {}", $err);
-        }
-
-        #[cfg(not(test))]
-        return Err($err);
-    }};
+    ($err:expr) => {
+        return Err($err)
+    };
 }
 
 impl<F: crate::factory::JsonFactory<Any = Value>> ValueBuilder<F> {
@@ -442,7 +433,6 @@ impl<F: crate::factory::JsonFactory<Any = Value>> ValueBuilder<F> {
         }
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     #[inline]
     pub fn pop(&mut self) -> Result<&mut Value, ZipperError> {
         match &mut self.state {
@@ -797,10 +787,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "operation would pop past the root")]
     fn builder_pop_errors() {
         let mut builder = ValueBuilder::<crate::factory::StdFactory>::default();
-        // Popping when empty should panic in test configuration
-        builder.pop().unwrap();
+        // Popping when empty should yield an error
+        assert_eq!(builder.pop(), Err(ZipperError::ExpectedNonEmptyPath));
     }
 }

--- a/crates/jsonmodem/tests/factory_std.rs
+++ b/crates/jsonmodem/tests/factory_std.rs
@@ -5,11 +5,11 @@ use jsonmodem::{JsonFactory, StdFactory, Value};
 fn std_factory_roundtrip() {
     let f = StdFactory;
     let mut arr = f.new_array();
-    f.push_array(&mut arr, f.into_any_bool(f.new_bool(true)));
+    f.push_array(&mut arr, f.any_from_bool(f.new_bool(true)));
     let mut obj = f.new_object();
-    f.insert_object(&mut obj, "n", f.into_any_num(f.new_number(1.0)));
-    let v_arr = f.into_any_array(arr);
-    let v_obj = f.into_any_object(obj);
+    f.insert_object(&mut obj, "n", f.any_from_num(f.new_number(1.0)));
+    let v_arr = f.any_from_array(arr);
+    let v_obj = f.any_from_object(obj);
     assert_eq!(v_arr, Value::Array(vec![Value::Boolean(true)]));
     assert_eq!(
         v_obj,


### PR DESCRIPTION
## Summary
- document chunk splitting helpers to replace missing panics doc lint
- rename JsonFactory conversion helpers and update callers to drop wrong-self-convention lint
- streamline ValueZipper error handling and remove enum glob imports

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`
- `maturin develop -m crates/jsonmodem-py/Cargo.toml --release` (failed: Couldn't find a virtualenv or conda environment)
- `pytest -q crates/jsonmodem-py/tests` (failed: ModuleNotFoundError: No module named 'jsonmodem')


------
https://chatgpt.com/codex/tasks/task_e_688dbd0d6de083209b4f6cdc9cf2fb69