### PR TITLE
Adjust Python package name

### DIFF
--- a/crates/jsonmodem-py/Cargo.toml
+++ b/crates/jsonmodem-py/Cargo.toml
@@ -7,12 +7,8 @@ license = "MIT OR Apache-2.0"
 description = "Python bindings for the jsonmodem Rust crate"
 
 [lib]
-name = "jsonmodem_py"
 crate-type = ["cdylib"]
 
 [dependencies]
 jsonmodem = { path = "../jsonmodem" }
 pyo3 = { version = "0.25", features = ["extension-module"] }
-
-[tool.maturin]
-module-name = "jsonmodem"

--- a/crates/jsonmodem-py/README.md
+++ b/crates/jsonmodem-py/README.md
@@ -1,3 +1,5 @@
 # jsonmodem-py
 
 Python bindings for the jsonmodem crate.
+
+The published Python package is named `jsonmodem` and exposes a module of the same name.

--- a/crates/jsonmodem-py/pyproject.toml
+++ b/crates/jsonmodem-py/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
-requires = ["maturin>=1,<2"]
+requires = ["maturin>=1.0"]
 build-backend = "maturin"
+
+[project]
+name = "jsonmodem"
+version = "0.1.0"
+
+[tool.maturin]
+module-name = "jsonmodem"


### PR DESCRIPTION
## Summary
- ensure jsonmodem-py builds Python package `jsonmodem`
- document Python package name

## Testing
- `cargo build --all --release --workspace`
- `cargo test --all --workspace --all-features --verbose`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`
- `maturin develop -m crates/jsonmodem-py/Cargo.toml --release`
- `.venv/bin/pytest -q crates/jsonmodem-py/tests`


------
https://chatgpt.com/codex/tasks/task_e_688dd5e42ab08320b71c9706e798646d