### PR TITLE
feat: Generic StreamingParser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
 name = "jsonmodem"
 version = "0.1.2"
 dependencies = [
+ "cfg-if",
  "criterion",
  "insta",
  "is_ci",

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -25,6 +25,7 @@ miri = ["bench-fast", "test-fast"]
 ouroboros = { version = "0.18.5", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 pyo3 = { version = "0.25.1", optional = true }
+cfg-if = "1.0.1"
 
 [dev-dependencies]
 insta = { version = "1.43.1", features = ["yaml"] }

--- a/crates/jsonmodem/src/event_stack.rs
+++ b/crates/jsonmodem/src/event_stack.rs
@@ -1,19 +1,20 @@
 use alloc::vec::Vec;
+use core::fmt::Debug;
 
 use crate::{
-    ParseEvent, Value,
-    factory::{JsonFactory, StdFactory},
+    ParseEvent,
+    factory::JsonFactory,
     value_zipper::{ValueBuilder, ZipperError},
 };
 
 #[derive(Debug)]
-pub(crate) struct EventStack<F: JsonFactory<Any = Value> = StdFactory> {
-    events: Vec<ParseEvent>,
-    builder: Option<ValueBuilder<F>>,
+pub(crate) struct EventStack<V: JsonFactory> {
+    events: Vec<ParseEvent<V>>,
+    builder: Option<ValueBuilder<V>>,
 }
 
-impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
-    pub(crate) fn new(events: Vec<ParseEvent>, builder: Option<ValueBuilder<F>>) -> Self {
+impl<V: JsonFactory> EventStack<V> {
+    pub(crate) fn new(events: Vec<ParseEvent<V>>, builder: Option<ValueBuilder<V>>) -> Self {
         Self { events, builder }
     }
 
@@ -22,46 +23,30 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
         self.events.len()
     }
 
-    pub(crate) fn pop(&mut self) -> Option<ParseEvent> {
+    pub(crate) fn pop(&mut self) -> Option<ParseEvent<V>> {
         self.events.pop()
     }
 
-    pub(crate) fn push(&mut self, mut event: ParseEvent) -> Result<(), ZipperError> {
+    pub(crate) fn push(&mut self, mut event: ParseEvent<V>) -> Result<(), ZipperError> {
         if let Some(ref mut builder) = self.builder {
             match &mut event {
                 // scalars
                 ParseEvent::Null { path } => {
-                    let v = {
-                        let f = builder.factory();
-                        f.any_from_null(f.new_null())
-                    };
-                    builder.set(path.last(), v)?;
+                    builder.set(path.last(), V::from_null(V::new_null()))?;
                 }
                 ParseEvent::Boolean { path, value } => {
-                    let v = {
-                        let f = builder.factory();
-                        f.any_from_bool(f.new_bool(*value))
-                    };
-                    builder.set(path.last(), v)?;
+                    builder.set(path.last(), V::from_bool(*value))?;
                 }
                 ParseEvent::Number { path, value } => {
-                    let v = {
-                        let f = builder.factory();
-                        f.any_from_num(f.new_number(*value))
-                    };
-                    builder.set(path.last(), v)?;
+                    builder.set(path.last(), V::from_num(*value))?;
                 }
                 ParseEvent::String { fragment, path, .. } => {
-                    let init = {
-                        let f = builder.factory();
-                        f.any_from_str(f.new_string(""))
-                    };
                     builder.mutate_with(
                         path.last(),
-                        || init,
+                        || V::from_str(V::Str::default()),
                         |v| {
-                            if let Value::String(s) = v {
-                                s.push_str(fragment);
+                            if let Some(s) = V::as_string_mut(v) {
+                                V::push_string(s, fragment);
                                 Ok(())
                             } else {
                                 Err(ZipperError::ExpectedString)
@@ -72,18 +57,10 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
 
                 // ── container starts ───────────────────────────────────────
                 ParseEvent::ObjectBegin { path } => {
-                    let init = {
-                        let f = builder.factory();
-                        f.any_from_object(f.new_object())
-                    };
-                    builder.enter_with(path.last(), || init)?;
+                    builder.enter_with(path.last(), || V::from_object(V::new_object()))?;
                 }
                 ParseEvent::ArrayStart { path } => {
-                    let init = {
-                        let f = builder.factory();
-                        f.any_from_array(f.new_array())
-                    };
-                    builder.enter_with(path.last(), || init)?;
+                    builder.enter_with(path.last(), || V::from_array(V::new_array()))?;
                 }
 
                 // ── container ends ─────────────────────────────────────────
@@ -91,7 +68,7 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
                     if path.is_empty() {
                         // Path is empty, use the root:
                         let root = core::mem::take(builder).into_value();
-                        if let Some(Value::Array(root_array)) = root {
+                        if let Some(Some(root_array)) = root.map(V::into_array) {
                             value.replace(root_array);
                         } else {
                             #[cfg(test)]
@@ -100,34 +77,28 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
                             #[cfg(not(test))]
                             return Err(ZipperError::ExpectedArray);
                         }
+                    } else if let Some(leaf_array) = V::as_array_mut(builder.pop()?) {
+                        value.replace(leaf_array.clone());
                     } else {
-                        // don't pop past root
-                        if let Value::Array(leaf_array) = builder.pop()? {
-                            value.replace(leaf_array.clone());
-                        } else {
-                            return Err(ZipperError::ExpectedArray);
-                        }
+                        return Err(ZipperError::ExpectedArray);
                     }
                 }
                 ParseEvent::ObjectEnd { path, value } => {
                     if path.is_empty() {
                         // Path is empty, use the root:
                         let root = core::mem::take(builder).into_value();
-                        if let Some(Value::Object(root_object)) = root {
+                        if let Some(Some(root_object)) = root.map(V::into_object) {
                             value.replace(root_object);
                         } else {
                             #[cfg(test)]
-                            panic!("Expected root to be an array");
+                            panic!("Expected root to be an object");
                             #[cfg(not(test))]
                             return Err(ZipperError::ExpectedObject);
                         }
+                    } else if let Some(leaf_object) = V::as_object_mut(builder.pop()?) {
+                        value.replace(leaf_object.clone());
                     } else {
-                        // don't pop past root
-                        if let Value::Object(leaf_object) = builder.pop()? {
-                            value.replace(leaf_object.clone());
-                        } else {
-                            return Err(ZipperError::ExpectedObject);
-                        }
+                        return Err(ZipperError::ExpectedObject);
                     }
                 }
             }
@@ -137,7 +108,7 @@ impl<F: JsonFactory<Any = Value> + Default> EventStack<F> {
         Ok(())
     }
 
-    pub(crate) fn read_root(&self) -> Option<&Value> {
+    pub(crate) fn read_root(&self) -> Option<&V> {
         self.builder.as_ref().and_then(|x| x.read_root())
     }
 }

--- a/crates/jsonmodem/src/lib.rs
+++ b/crates/jsonmodem/src/lib.rs
@@ -32,7 +32,7 @@ pub use alloc::vec;
 pub use chunk_utils::{produce_chunks, produce_prefixes};
 pub use error::ParserError;
 pub use event::{ParseEvent, PathComponent, PathComponentFrom};
-pub use factory::{JsonFactory, StdFactory};
+pub use factory::JsonFactory;
 pub use options::{NonScalarValueMode, ParserOptions, StringValueMode};
 pub use parser::StreamingParser;
 pub use streaming_values::{StreamingValue, StreamingValuesParser};

--- a/crates/jsonmodem/src/value.rs
+++ b/crates/jsonmodem/src/value.rs
@@ -2,7 +2,10 @@
 //!
 //! This module defines the [`Value`] enum, which represents any valid JSON
 //! value, and provides helper functions for escaping JSON strings.
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+#![allow(clippy::inline_always)]
+use alloc::{borrow::ToOwned, collections::BTreeMap, string::String, vec::Vec};
+
+use crate::JsonFactory;
 
 pub type Map = BTreeMap<String, Value>;
 pub type Array = Vec<Value>;
@@ -268,5 +271,193 @@ impl core::fmt::Display for Value {
                 f.write_str("}")
             }
         }
+    }
+}
+
+impl JsonFactory for Value {
+    type Str = String;
+    type Num = f64;
+    type Bool = bool;
+    type Null = ();
+    type Array = Vec<Value>;
+    type Object = BTreeMap<String, Value>;
+
+    #[inline(always)]
+    fn new_null() {
+        // unit type has a default return
+    }
+
+    #[inline(always)]
+    fn new_bool(b: bool) -> bool {
+        b
+    }
+
+    #[inline(always)]
+    fn new_number(n: f64) -> f64 {
+        n
+    }
+
+    #[inline(always)]
+    fn new_string(s: String) -> String {
+        s
+    }
+
+    #[inline(always)]
+    fn new_array() -> Vec<Value> {
+        Vec::new()
+    }
+
+    #[inline(always)]
+    fn new_object() -> BTreeMap<String, Value> {
+        BTreeMap::new()
+    }
+
+    #[inline(always)]
+    fn push_array(array: &mut Vec<Value>, val: Self) {
+        array.push(val);
+    }
+
+    #[inline(always)]
+    fn insert_object(obj: &mut BTreeMap<String, Value>, key: &str, val: Self) {
+        obj.insert(key.to_owned(), val);
+    }
+
+    #[inline(always)]
+    fn from_str(s: Self::Str) -> Value {
+        Value::String(s)
+    }
+
+    #[inline(always)]
+    fn from_num(n: Self::Num) -> Value {
+        Value::Number(n)
+    }
+
+    #[inline(always)]
+    fn from_bool(b: Self::Bool) -> Value {
+        Value::Boolean(b)
+    }
+
+    #[inline(always)]
+    fn from_null(_n: ()) -> Value {
+        Value::Null
+    }
+
+    #[inline(always)]
+    fn from_array(a: Vec<Value>) -> Value {
+        Value::Array(a)
+    }
+
+    #[inline(always)]
+    fn from_object(o: BTreeMap<String, Value>) -> Value {
+        Value::Object(o)
+    }
+
+    #[inline(always)]
+    fn kind(v: &Self) -> crate::factory::ValueKind {
+        match v {
+            Value::Null => crate::factory::ValueKind::Null,
+            Value::Boolean(_) => crate::factory::ValueKind::Bool,
+            Value::Number(_) => crate::factory::ValueKind::Num,
+            Value::String(_) => crate::factory::ValueKind::Str,
+            Value::Array(_) => crate::factory::ValueKind::Array,
+            Value::Object(_) => crate::factory::ValueKind::Object,
+        }
+    }
+
+    #[inline(always)]
+    fn push_string(string: &mut Self::Str, val: &Self::Str) {
+        string.push_str(val);
+    }
+
+    #[inline(always)]
+    fn push_str(string: &mut Self::Str, val: &str) {
+        string.push_str(val);
+    }
+
+    #[inline(always)]
+    fn as_string_mut(v: &mut Self) -> Option<&mut String> {
+        if let Value::String(s) = v {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn as_array_mut(v: &mut Self) -> Option<&mut Vec<Value>> {
+        if let Value::Array(a) = v {
+            Some(a)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn as_object_mut(v: &mut Self) -> Option<&mut BTreeMap<String, Value>> {
+        if let Value::Object(o) = v {
+            Some(o)
+        } else {
+            None
+        }
+    }
+
+    fn into_array(v: Self) -> Option<Vec<Value>>
+    where
+        Self: Sized,
+    {
+        if let Value::Array(arr) = v {
+            Some(arr)
+        } else {
+            None
+        }
+    }
+
+    fn into_object(v: Self) -> Option<BTreeMap<String, Value>>
+    where
+        Self: Sized,
+    {
+        if let Value::Object(obj) = v {
+            Some(obj)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn object_get_mut<'a>(
+        obj: &'a mut BTreeMap<String, Value>,
+        key: &str,
+    ) -> Option<&'a mut Value> {
+        obj.get_mut(key)
+    }
+
+    #[inline(always)]
+    fn object_insert(obj: &mut BTreeMap<String, Value>, key: String, val: Value) -> &mut Value {
+        use alloc::collections::btree_map::Entry;
+
+        match obj.entry(key) {
+            Entry::Occupied(occ) => {
+                let slot = occ.into_mut();
+                *slot = val;
+                slot
+            }
+            Entry::Vacant(slot) => slot.insert(val),
+        }
+    }
+
+    #[inline(always)]
+    fn array_get_mut(arr: &mut Vec<Value>, idx: usize) -> Option<&mut Value> {
+        arr.get_mut(idx)
+    }
+
+    #[inline(always)]
+    fn array_push(arr: &mut Vec<Value>, val: Value) -> &mut Value {
+        arr.push(val);
+        arr.last_mut().expect("just pushed")
+    }
+
+    #[inline(always)]
+    fn array_len(arr: &Vec<Value>) -> usize {
+        arr.len()
     }
 }

--- a/crates/jsonmodem/tests/factory_std.rs
+++ b/crates/jsonmodem/tests/factory_std.rs
@@ -1,15 +1,14 @@
 #![allow(missing_docs)]
-use jsonmodem::{JsonFactory, StdFactory, Value};
+use jsonmodem::{JsonFactory, Value};
 
 #[test]
 fn std_factory_roundtrip() {
-    let f = StdFactory;
-    let mut arr = f.new_array();
-    f.push_array(&mut arr, f.any_from_bool(f.new_bool(true)));
-    let mut obj = f.new_object();
-    f.insert_object(&mut obj, "n", f.any_from_num(f.new_number(1.0)));
-    let v_arr = f.any_from_array(arr);
-    let v_obj = f.any_from_object(obj);
+    let mut arr = Value::new_array();
+    Value::push_array(&mut arr, Value::from_bool(Value::new_bool(true)));
+    let mut obj = Value::new_object();
+    Value::insert_object(&mut obj, "n", Value::from_num(Value::new_number(1.0)));
+    let v_arr = Value::from_array(arr);
+    let v_obj = Value::from_object(obj);
     assert_eq!(v_arr, Value::Array(vec![Value::Boolean(true)]));
     assert_eq!(
         v_obj,


### PR DESCRIPTION
The StreamingParser implementation is now fully generic over a JsonFactory trait, which allows us to implement StreamingParser that natively outputs Python structs without additional copies.