### PR TITLE
feat(py): split embed and ext-module features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,6 @@ dependencies = [
  "jiter",
  "ouroboros",
  "paste",
- "pyo3",
  "quickcheck",
  "quickcheck_macros",
  "rstest",
@@ -518,6 +517,7 @@ version = "0.1.0"
 dependencies = [
  "jsonmodem",
  "pyo3",
+ "pyo3-build-config",
 ]
 
 [[package]]

--- a/crates/jsonmodem-py/Cargo.toml
+++ b/crates/jsonmodem-py/Cargo.toml
@@ -7,8 +7,16 @@ license = "MIT OR Apache-2.0"
 description = "Python bindings for the jsonmodem Rust crate"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["embed"]
+embed = ["pyo3/auto-initialize"]
+ext-module = ["pyo3/extension-module"]
 
 [dependencies]
-jsonmodem = { path = "../jsonmodem" }
-pyo3 = { version = "0.25", features = ["extension-module"] }
+jsonmodem = { path = "../jsonmodem", default-features = false }
+pyo3 = { version = "0.25", optional = true }
+
+[build-dependencies]
+pyo3-build-config = "0.25"

--- a/crates/jsonmodem-py/build.rs
+++ b/crates/jsonmodem-py/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}

--- a/crates/jsonmodem-py/pyproject.toml
+++ b/crates/jsonmodem-py/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0"]
+requires = ["maturin>=1.5,<2"]
 build-backend = "maturin"
 
 [project]
@@ -8,3 +8,4 @@ version = "0.1.0"
 
 [tool.maturin]
 module-name = "jsonmodem"
+features = ["ext-module"]

--- a/crates/jsonmodem-py/src/lib.rs
+++ b/crates/jsonmodem-py/src/lib.rs
@@ -1,7 +1,15 @@
+mod pyfactory;
+mod pyvalue;
+
+pub use pyfactory::PyFactory;
+pub use pyvalue::PyJsonValue;
+
+use ::jsonmodem::StreamingParserImpl;
+pub type PyStreamingParser = StreamingParserImpl<PyJsonValue>;
+
 use pyo3::prelude::*;
 
 #[pymodule]
 pub fn jsonmodem(_py: Python<'_>, _m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // empty for now
     Ok(())
 }

--- a/crates/jsonmodem-py/src/pyfactory.rs
+++ b/crates/jsonmodem-py/src/pyfactory.rs
@@ -1,0 +1,95 @@
+use jsonmodem::JsonValueFactory;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyList, PyString};
+
+use crate::pyvalue::PyJsonValue;
+
+/// Factory that builds Python objects for the streaming parser.
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
+pub struct PyFactory;
+
+impl JsonValueFactory for PyFactory {
+    type Value = PyJsonValue;
+
+    fn new_null(&mut self) -> () {}
+    fn new_bool(&mut self, b: bool) -> bool {
+        b
+    }
+    fn new_number(&mut self, n: f64) -> f64 {
+        n
+    }
+    fn new_string(&mut self, s: &str) -> String {
+        s.into()
+    }
+    fn new_array(&mut self) -> Vec<PyJsonValue> {
+        Vec::new()
+    }
+    fn new_object(&mut self) -> Vec<(String, PyJsonValue)> {
+        Vec::new()
+    }
+
+    fn push_string(&mut self, tgt: &mut String, src: &String) {
+        tgt.push_str(src);
+    }
+    fn push_str(&mut self, tgt: &mut String, src: &str) {
+        tgt.push_str(src);
+    }
+    fn push_array(&mut self, arr: &mut Vec<PyJsonValue>, v: PyJsonValue) {
+        arr.push(v);
+    }
+    fn insert_object(&mut self, o: &mut Vec<(String, PyJsonValue)>, k: &str, v: PyJsonValue) {
+        o.push((k.into(), v));
+    }
+
+    fn build_from_str(&mut self, s: String) -> PyJsonValue {
+        Python::with_gil(|py| PyJsonValue(PyString::new(py, &s).into()))
+    }
+    fn build_from_num(&mut self, n: f64) -> PyJsonValue {
+        Python::with_gil(|py| PyJsonValue(PyFloat::new(py, n).into()))
+    }
+    fn build_from_bool(&mut self, b: bool) -> PyJsonValue {
+        Python::with_gil(|py| {
+            let obj: Py<PyBool> = PyBool::new(py, b).into();
+            PyJsonValue(obj.into())
+        })
+    }
+    fn build_from_null(&mut self, _n: ()) -> PyJsonValue {
+        Python::with_gil(|py| PyJsonValue(py.None().into()))
+    }
+    fn build_from_array(&mut self, a: Vec<PyJsonValue>) -> PyJsonValue {
+        Python::with_gil(|py| {
+            let list = PyList::empty(py);
+            for v in a {
+                list.append(v.0).unwrap();
+            }
+            PyJsonValue(list.into())
+        })
+    }
+    fn build_from_object(&mut self, o: Vec<(String, PyJsonValue)>) -> PyJsonValue {
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            for (k, v) in o {
+                dict.set_item(k, v.0).unwrap();
+            }
+            PyJsonValue(dict.into())
+        })
+    }
+
+    fn object_insert<'a, 'b: 'a>(
+        &'a mut self,
+        o: &'b mut Vec<(String, PyJsonValue)>,
+        k: String,
+        v: PyJsonValue,
+    ) -> &'b mut PyJsonValue {
+        o.push((k, v));
+        &mut o.last_mut().unwrap().1
+    }
+    fn array_push<'a, 'b: 'a>(
+        &'a mut self,
+        a: &'b mut Vec<PyJsonValue>,
+        v: PyJsonValue,
+    ) -> &'b mut PyJsonValue {
+        a.push(v);
+        a.last_mut().unwrap()
+    }
+}

--- a/crates/jsonmodem-py/src/pyvalue.rs
+++ b/crates/jsonmodem-py/src/pyvalue.rs
@@ -1,0 +1,111 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyList, PyString};
+
+use jsonmodem::{JsonValue, ValueKind};
+
+/// Wrapper around a Python object implementing [`JsonValue`].
+pub struct PyJsonValue(pub Py<PyAny>);
+
+impl Clone for PyJsonValue {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| Self(self.0.clone_ref(py)))
+    }
+}
+
+impl core::fmt::Debug for PyJsonValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Python::with_gil(|py| match self.0.bind(py).repr() {
+            Ok(rep) => write!(f, "PyJsonValue({})", rep.to_string_lossy()),
+            Err(_) => write!(f, "PyJsonValue(<repr error>)"),
+        })
+    }
+}
+
+impl PartialEq for PyJsonValue {
+    fn eq(&self, other: &Self) -> bool {
+        Python::with_gil(|py| self.0.bind(py).eq(other.0.bind(py)).unwrap_or(false))
+    }
+}
+
+impl Default for PyJsonValue {
+    fn default() -> Self {
+        Python::with_gil(|py| Self(py.None().into()))
+    }
+}
+
+impl JsonValue for PyJsonValue {
+    type Str = String;
+    type Num = f64;
+    type Bool = bool;
+    type Null = ();
+    type Array = Vec<PyJsonValue>;
+    type Object = Vec<(String, PyJsonValue)>;
+
+    fn kind(v: &Self) -> ValueKind {
+        Python::with_gil(|py| {
+            let obj = v.0.bind(py);
+            if obj.is_none() {
+                ValueKind::Null
+            } else if obj.is_instance(&py.get_type::<PyBool>()).unwrap_or(false) {
+                ValueKind::Bool
+            } else if obj.is_instance(&py.get_type::<PyFloat>()).unwrap_or(false) {
+                ValueKind::Num
+            } else if obj.is_instance(&py.get_type::<PyString>()).unwrap_or(false) {
+                ValueKind::Str
+            } else if obj.is_instance(&py.get_type::<PyList>()).unwrap_or(false) {
+                ValueKind::Array
+            } else if obj.is_instance(&py.get_type::<PyDict>()).unwrap_or(false) {
+                ValueKind::Object
+            } else {
+                ValueKind::Null
+            }
+        })
+    }
+
+    fn as_string_mut(_v: &mut Self) -> Option<&mut Self::Str> {
+        None
+    }
+
+    fn as_array_mut(_v: &mut Self) -> Option<&mut Self::Array> {
+        None
+    }
+
+    fn as_object_mut(_v: &mut Self) -> Option<&mut Self::Object> {
+        None
+    }
+
+    fn object_get_mut<'a>(obj: &'a mut Self::Object, key: &str) -> Option<&'a mut Self> {
+        obj.iter_mut().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+
+    fn array_get_mut(arr: &mut Self::Array, idx: usize) -> Option<&mut Self> {
+        arr.get_mut(idx)
+    }
+
+    fn array_len(arr: &Self::Array) -> usize {
+        arr.len()
+    }
+
+    fn into_array(v: Self) -> Option<Self::Array> {
+        Python::with_gil(|py| {
+            let obj = v.0.into_bound(py);
+            obj.downcast::<PyList>()
+                .ok()
+                .map(|list| list.iter().map(|item| PyJsonValue(item.into())).collect())
+        })
+    }
+
+    fn into_object(v: Self) -> Option<Self::Object> {
+        Python::with_gil(|py| {
+            let obj = v.0.into_bound(py);
+            obj.downcast::<PyDict>().ok().map(|dict| {
+                dict.iter()
+                    .map(|(k, v)| {
+                        let key: String = k.extract().unwrap_or_default();
+                        (key, PyJsonValue(v.into()))
+                    })
+                    .collect()
+            })
+        })
+    }
+}

--- a/crates/jsonmodem-py/tests/py_parser.rs
+++ b/crates/jsonmodem-py/tests/py_parser.rs
@@ -1,0 +1,13 @@
+use jsonmodem::ParserOptions;
+use jsonmodem_py::{PyFactory, PyStreamingParser};
+
+#[test]
+fn streaming_parser_smoke() {
+    let mut parser = PyStreamingParser::new(ParserOptions::default());
+    for ev in parser.feed_with(PyFactory, "{\"a\":[1,2]}") {
+        ev.unwrap();
+    }
+    for ev in parser.finish_with(PyFactory) {
+        ev.unwrap();
+    }
+}

--- a/crates/jsonmodem-py/tests/py_scalar.rs
+++ b/crates/jsonmodem-py/tests/py_scalar.rs
@@ -1,0 +1,29 @@
+use jsonmodem::JsonValueFactory;
+use jsonmodem_py::PyFactory;
+use pyo3::Python;
+use pyo3::types::{PyAnyMethods, PyString, PyStringMethods};
+
+#[test]
+fn pyfactory_scalar_roundtrip() {
+    let mut f = PyFactory;
+
+    let null_token = f.new_null();
+    let v_null = f.build_from_null(null_token);
+
+    let bool_token = f.new_bool(true);
+    let v_bool = f.build_from_bool(bool_token);
+
+    let num_token = f.new_number(3.5);
+    let v_num = f.build_from_num(num_token);
+
+    let str_token = f.new_string("hi");
+    let v_str = f.build_from_str(str_token);
+
+    Python::with_gil(|py| {
+        assert!(v_null.0.bind(py).is_none());
+        assert_eq!(v_bool.0.bind(py).extract::<bool>().unwrap(), true);
+        assert_eq!(v_num.0.bind(py).extract::<f64>().unwrap(), 3.5);
+        let s = v_str.0.bind(py).downcast::<PyString>().unwrap();
+        assert_eq!(s.to_str().unwrap(), "hi");
+    });
+}

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -15,7 +15,6 @@ fuzzing = []
 serde = []
 bench = []
 comparison = []
-pyo3 = ["dep:pyo3"]
 bench-fast = []
 test-fast = []
 # Enabling `miri` pulls in the faster test and benchmark configurations.
@@ -24,7 +23,6 @@ miri = ["bench-fast", "test-fast"]
 [dependencies]
 ouroboros = { version = "0.18.5", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-pyo3 = { version = "0.25.1", optional = true }
 cfg-if = "1.0.1"
 
 [dev-dependencies]

--- a/crates/jsonmodem/src/lib.rs
+++ b/crates/jsonmodem/src/lib.rs
@@ -34,7 +34,7 @@ pub use error::ParserError;
 pub use event::{ParseEvent, PathComponent, PathComponentFrom};
 pub use factory::{JsonValue, JsonValueFactory, StdValueFactory, ValueKind};
 pub use options::{NonScalarValueMode, ParserOptions, StringValueMode};
-pub use parser::StreamingParser;
+pub use parser::{StreamingParser, StreamingParserImpl};
 pub use streaming_values::{StreamingValue, StreamingValuesParser};
 pub use value::{Array, Map, Value};
 


### PR DESCRIPTION
## Summary
- support embed and ext-module feature flags for jsonmodem-py
- provide zero-sized PyFactory and basic parser smoke test
- wire maturin build features and link args for extension builds

## Testing
- `cargo test -p jsonmodem-py`
- `cargo build -p jsonmodem-py --no-default-features -F ext-module`


------
https://chatgpt.com/codex/tasks/task_e_688fe531be9483209e6b3742ee6fd174