### PR TITLE
Avoid panics on invalid numbers in parser

### DIFF
--- a/crates/jsonmodem/src/parser.rs
+++ b/crates/jsonmodem/src/parser.rs
@@ -827,7 +827,9 @@ impl<V: JsonValue> StreamingParserImpl<V> {
                     Ok(None)
                 }
                 _ => {
-                    let num = self.buffer.parse::<f64>().unwrap();
+                    let Ok(num) = self.buffer.parse::<f64>() else {
+                        return Err(self.syntax_error(format!("invalid number {}", self.buffer)));
+                    };
                     self.buffer.clear();
                     Ok(Some(self.new_token(Token::Number(num), false)))
                 }
@@ -861,7 +863,9 @@ impl<V: JsonValue> StreamingParserImpl<V> {
                     Ok(None)
                 }
                 _ => {
-                    let num = self.buffer.parse::<f64>().unwrap();
+                    let Ok(num) = self.buffer.parse::<f64>() else {
+                        return Err(self.syntax_error(format!("invalid number {}", self.buffer)));
+                    };
                     self.buffer.clear();
                     Ok(Some(self.new_token(Token::Number(num), false)))
                 }
@@ -914,7 +918,9 @@ impl<V: JsonValue> StreamingParserImpl<V> {
                     Ok(None)
                 }
                 _ => {
-                    let num = self.buffer.parse::<f64>().unwrap();
+                    let Ok(num) = self.buffer.parse::<f64>() else {
+                        return Err(self.syntax_error(format!("invalid number {}", self.buffer)));
+                    };
                     self.buffer.clear();
                     Ok(Some(self.new_token(Token::Number(num), false)))
                 }
@@ -980,7 +986,9 @@ impl<V: JsonValue> StreamingParserImpl<V> {
                     Ok(None)
                 }
                 _ => {
-                    let num = self.buffer.parse::<f64>().unwrap();
+                    let Ok(num) = self.buffer.parse::<f64>() else {
+                        return Err(self.syntax_error(format!("invalid number {}", self.buffer)));
+                    };
                     self.buffer.clear();
                     Ok(Some(self.new_token(Token::Number(num), false)))
                 }

--- a/crates/jsonmodem/src/tests/parse_bad.rs
+++ b/crates/jsonmodem/src/tests/parse_bad.rs
@@ -89,6 +89,24 @@ fn error_invalid_characters_following_exponent_sign() {
 }
 
 #[test]
+fn error_missing_exponent_digits_with_space() {
+    let mut parser = StreamingParser::new(ParserOptions::default());
+    let err = parser.feed("1e ").last().unwrap().unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character ' ' at 1:3");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 3);
+}
+
+#[test]
+fn error_missing_exponent_digits_with_sign() {
+    let mut parser = StreamingParser::new(ParserOptions::default());
+    let err = parser.feed("1e+ ").last().unwrap().unwrap_err();
+    assert_eq!(err.to_string(), "JSON5: invalid character ' ' at 1:4");
+    assert_eq!(err.line, 1);
+    assert_eq!(err.column, 4);
+}
+
+#[test]
 fn error_invalid_new_lines_in_strings() {
     let mut parser = StreamingParser::new(ParserOptions::default());
     let err = parser.feed("\"\n\"").last().unwrap().unwrap_err();


### PR DESCRIPTION
## Summary
- avoid panicking when an invalid float is encountered
- test exponent cases missing digits

## Testing
- `cargo build --release -p jsonmodem --features bench-fast --features test-fast`
- `cargo test -p jsonmodem --features bench-fast --features test-fast`
- `cargo clippy --workspace --all-targets --exclude jsonmodem-py --exclude jsonmodem-fuzz --features bench-fast --features test-fast -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `./actionlint -color`
- `maturin develop -m crates/jsonmodem-py/Cargo.toml --release`
- `.venv/bin/pytest -q crates/jsonmodem-py/tests`


------
https://chatgpt.com/codex/tasks/task_e_689057f4212483208f7b1301fc6487ad