### PR TITLE
Use Arc<str> for path component keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,12 +364,6 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -485,14 +473,11 @@ dependencies = [
 name = "jsonmodem"
 version = "0.1.2"
 dependencies = [
- "cfg-if",
  "criterion",
  "insta",
  "is_ci",
  "jiter",
- "ouroboros",
  "paste",
- "pyo3",
  "quickcheck",
  "quickcheck_macros",
  "rstest",
@@ -640,30 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "ouroboros"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,19 +704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
-]
-
-[[package]]
 name = "pyo3"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +759,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1413,12 +1361,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -12,24 +12,20 @@ rust-version = "1.85"
 [features]
 default = []
 fuzzing = []
-serde = []
+serde = ["dep:serde"]
 bench = []
 comparison = []
-pyo3 = ["dep:pyo3"]
 bench-fast = []
 test-fast = []
 # Enabling `miri` pulls in the faster test and benchmark configurations.
 miri = ["bench-fast", "test-fast"]
 
 [dependencies]
-ouroboros = { version = "0.18.5", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-pyo3 = { version = "0.25.1", optional = true }
-cfg-if = "1.0.1"
+serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 
 [dev-dependencies]
 insta = { version = "1.43.1", features = ["yaml"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 quickcheck = "1.0"
 rstest = "0.25.0"
 quickcheck_macros = "1.1.0"

--- a/crates/jsonmodem/benches/parse_partial_json_port.rs
+++ b/crates/jsonmodem/benches/parse_partial_json_port.rs
@@ -436,6 +436,7 @@ mod tests {
         assert_eq!(state, ParseState::RepairedParse);
         assert_eq!(val.unwrap(), serde_json::json!({}));
     }
+
     #[test]
     fn unicode_inside_unterminated_string() {
         let inp = r#"{"msg":"¡Hola"#;

--- a/crates/jsonmodem/src/lib.rs
+++ b/crates/jsonmodem/src/lib.rs
@@ -36,7 +36,7 @@ pub use factory::{JsonValue, JsonValueFactory, StdValueFactory, ValueKind};
 pub use options::{NonScalarValueMode, ParserOptions, StringValueMode};
 pub use parser::StreamingParser;
 pub use streaming_values::{StreamingValue, StreamingValuesParser};
-pub use value::{Array, Map, Value};
+pub use value::{Array, Map, Str, Value};
 
 /// Macro to build a `Vec<PathComponent>` from a heterogeneous list of keys and
 /// indices.

--- a/crates/jsonmodem/src/tests/arbitrary.rs
+++ b/crates/jsonmodem/src/tests/arbitrary.rs
@@ -48,7 +48,7 @@ impl Arbitrary for Value {
                         for _ in 0..len {
                             let key = String::arbitrary(g);
                             let val = gen_val(g, depth - 1);
-                            map.insert(key, val);
+                            map.insert(key.into(), val);
                         }
                         Value::Object(map)
                     }

--- a/crates/jsonmodem/src/tests/parse_good.rs
+++ b/crates/jsonmodem/src/tests/parse_good.rs
@@ -1,4 +1,4 @@
-use alloc::{string::ToString, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 
 use crate::{
     ParseEvent, StreamingParser, Value,
@@ -55,25 +55,25 @@ fn test_empty_object() {
 #[test]
 fn test_single_property() {
     let mut map = Map::new();
-    map.insert("a".to_string(), Value::Number(1.0));
+    map.insert("a".into(), Value::Number(1.0));
     assert_eq!(finish_seq(&["{\"a\":1}"]), Value::Object(map));
 }
 
 #[test]
 fn test_multiple_properties() {
     let mut map = Map::new();
-    map.insert("abc".to_string(), Value::Number(1.0));
-    map.insert("def".to_string(), Value::Number(2.0));
+    map.insert("abc".into(), Value::Number(1.0));
+    map.insert("def".into(), Value::Number(2.0));
     assert_eq!(finish_seq(&["{\"abc\":1,\"def\":2}"]), Value::Object(map));
 }
 
 #[test]
 fn test_nested_objects() {
     let mut inner = Map::new();
-    inner.insert("b".to_string(), Value::Number(2.0));
+    inner.insert("b".into(), Value::Number(2.0));
 
     let mut outer = Map::new();
-    outer.insert("a".to_string(), Value::Object(inner));
+    outer.insert("a".into(), Value::Object(inner));
 
     assert_eq!(finish_seq(&["{\"a\":{\"b\":2}}"]), Value::Object(outer));
 }
@@ -148,7 +148,7 @@ fn test_numbers() {
 #[test]
 fn test_preserves_proto_property() {
     let mut map = Map::new();
-    map.insert("__proto__".to_string(), Value::Number(1.0));
+    map.insert("__proto__".into(), Value::Number(1.0));
     assert_eq!(finish_seq(&["{\"__proto__\":1}"]), Value::Object(map));
 }
 

--- a/crates/jsonmodem/src/tests/property_multivalue.rs
+++ b/crates/jsonmodem/src/tests/property_multivalue.rs
@@ -27,7 +27,7 @@ fn repro_multi_value_string_root() {
         &events,
         &[ParseEvent::String {
             path: vec![],
-            fragment: String::from("x"),
+            fragment: "x".into(),
             is_final: true,
             value: None,
         },]
@@ -35,7 +35,7 @@ fn repro_multi_value_string_root() {
     let reconstructed = reconstruct_values(events);
     // Expect one string root, but current implementation drops string roots
     // entirely.
-    assert_eq!(reconstructed, vec![Value::String(String::from("x"))]);
+    assert_eq!(reconstructed, vec![Value::String("x".into())]);
 }
 
 /// Property: A stream consisting of multiple JSON roots must round-trip through

--- a/crates/jsonmodem/src/value.rs
+++ b/crates/jsonmodem/src/value.rs
@@ -4,7 +4,10 @@
 //! value, and provides helper functions for escaping JSON strings.
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-pub type Map = BTreeMap<String, Value>;
+use crate::event::Key;
+
+pub type Str = String;
+pub type Map = BTreeMap<Key, Value>;
 pub type Array = Vec<Value>;
 
 /// A JSON value as defined by [RFC 8259].
@@ -25,7 +28,7 @@ pub type Array = Vec<Value>;
 ///
 /// // Creating a JSON object:
 /// let mut map = Map::new();
-/// map.insert("key".to_string(), Value::String("value".into()));
+/// map.insert("key".into(), Value::String("value".into()));
 /// let v = Value::Object(map);
 /// assert_eq!(v.to_string(), r#"{"key":"value"}"#);
 /// ```
@@ -43,7 +46,7 @@ pub enum Value {
     Null,
     Boolean(bool),
     Number(f64),
-    String(String),
+    String(Str),
     Array(Array),
     Object(Map),
 }
@@ -78,8 +81,8 @@ impl From<Vec<Value>> for Value {
     }
 }
 
-impl From<BTreeMap<String, Value>> for Value {
-    fn from(v: BTreeMap<String, Value>) -> Self {
+impl From<BTreeMap<Key, Value>> for Value {
+    fn from(v: BTreeMap<Key, Value>) -> Self {
         Self::Object(v)
     }
 }

--- a/crates/jsonmodem/tests/factory_std.rs
+++ b/crates/jsonmodem/tests/factory_std.rs
@@ -19,6 +19,6 @@ fn std_factory_roundtrip() {
     assert_eq!(v_arr, Value::Array(vec![Value::Boolean(true)]));
     assert_eq!(
         v_obj,
-        Value::Object([("n".to_string(), Value::Number(1.0))].into())
+        Value::Object([("n".into(), Value::Number(1.0))].into())
     );
 }


### PR DESCRIPTION
This improves the `streaming_json_large/streaming_parser_none/5000` benchmark by another ~10% with a smaller improvement to `streaming_json_large/streaming_values_parser/5000` (full partial JSON value iterator.)

For the latter, we will likely optimize in Rust via persistent data structures as in https://github.com/AaronFriel/jsonmodem/pull/56.

Removes unnecessary dependencies with default features.

Before:
```
streaming_json_large/streaming_parser_none/5000
                        time:   [668.03 µs 670.06 µs 672.45 µs]
streaming_json_large/streaming_parser_roots/5000
                        time:   [746.90 µs 749.92 µs 753.45 µs]
streaming_json_large/streaming_parser_all/5000
                        time:   [815.34 µs 817.98 µs 820.89 µs]
streaming_json_large/streaming_values_parser/5000
                        time:   [23.458 ms 23.523 ms 23.597 ms]
```

After:

```
streaming_json_large/streaming_parser_none/5000
                        time:   [605.09 µs 605.44 µs 605.88 µs]
streaming_json_large/streaming_parser_roots/5000
                        time:   [637.20 µs 638.47 µs 640.72 µs]
streaming_json_large/streaming_parser_all/5000
                        time:   [677.24 µs 677.53 µs 677.84 µs]
streaming_json_large/streaming_values_parser/5000
                        time:   [14.294 ms 14.358 ms 14.420 ms]
```

Fairly significant improvement across the board.

------
https://chatgpt.com/codex/tasks/task_e_68992414aba48320ab69880e72e8af89