### PR TITLE
feat: Add immutable backend

### DIFF
--- a/.agent/check.sh
+++ b/.agent/check.sh
@@ -38,17 +38,18 @@ EXCLUDE_ARGS=(--exclude "$FUZZ_CRATE" --exclude jsonmodem-fuzz --exclude jsonmod
 # Speed up local iteration by enabling lighter-weight test and benchmark
 # configurations. CI runs without these features for full coverage.
 FAST_ENV=(JSONMODEM_TEST_FAST=1 JSONMODEM_BENCH_FAST=1)
+FEATURE_ARGS=(--features im)
 
-run_step "build (release)"  env "${FAST_ENV[@]}" cargo build  --workspace --release              "${EXCLUDE_ARGS[@]}"
-run_step "tests"            env "${FAST_ENV[@]}" cargo test   --workspace --verbose              "${EXCLUDE_ARGS[@]}"
-run_step "clippy"           env "${FAST_ENV[@]}" cargo clippy --workspace --all-targets          "${EXCLUDE_ARGS[@]}" \
+run_step "build (release)"  env "${FAST_ENV[@]}" cargo build  --workspace --release              "${EXCLUDE_ARGS[@]}" "${FEATURE_ARGS[@]}"
+run_step "tests"            env "${FAST_ENV[@]}" cargo test   --workspace --verbose              "${EXCLUDE_ARGS[@]}" "${FEATURE_ARGS[@]}"
+run_step "clippy"           env "${FAST_ENV[@]}" cargo clippy --workspace --all-targets          "${EXCLUDE_ARGS[@]}" "${FEATURE_ARGS[@]}" \
                                -- -D warnings
-run_step "docs (public)"    env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps "${EXCLUDE_ARGS[@]}"
+run_step "docs (public)"    env RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps "${EXCLUDE_ARGS[@]}" "${FEATURE_ARGS[@]}"
 
 # Extra clippy pass that compiles under the same cfg flags Miri uses.
 run_step "clippy (cfg=miri)" \
          env RUSTFLAGS="--cfg miri" \
-         env "${FAST_ENV[@]}" cargo clippy --workspace --all-targets "${EXCLUDE_ARGS[@]}" \
+         env "${FAST_ENV[@]}" cargo clippy --workspace --all-targets "${EXCLUDE_ARGS[@]}" "${FEATURE_ARGS[@]}" \
            -- -D warnings
 
 ###############################################################################

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 /target
+/third_party
 /tmp
 /vendor
 *.pending-snap
 actionlint
 
 # jsonmodem-py (Python bindings) build artifacts
+/.venv
 /crates/jsonmodem-py/target/
 /crates/jsonmodem-py/.pytest_cache/
 /crates/jsonmodem-py/python/jsonmodem/_jsonmodem*.so
@@ -15,18 +17,6 @@ actionlint
 __pycache__/
 dist/
 *.py[cod]
-# jsonmodem-py (Python bindings) build artifacts
-/crates/jsonmodem-py/target/
-/crates/jsonmodem-py/.pytest_cache/
-/crates/jsonmodem-py/python/jsonmodem/_jsonmodem*.so
-/crates/jsonmodem-py/python/jsonmodem/_jsonmodem*.pyd
-/crates/jsonmodem-py/python/jsonmodem/__pycache__/
-
-# General Python data anywhere in the repo
-__pycache__/
-dist/
-*.py[cod]
-.venv
 
 # AGENTS metadata
 .agent/.setup_py_done
@@ -37,6 +27,3 @@ dist/
 /perf.data
 /perf.data.old
 /recent.log
-
-# Third-party research copies
-/third_party/jiter/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ workflow when adding or updating tests.
 
 Following these rules ensures that contributors can run and update snapshots
 consistently and that CI remains deterministic.
+
 # ExecPlans
 
 When writing complex features or significant refactors, use an ExecPlan (as described in PLANS.md) from design to implementation. ExecPlans are living documents and should be referred to and updated frequently throughout implementation. Store new execplans in plans/$short-feature-name/, e.g.: plans/py for the Python library.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
+dependencies = [
+ "triomphe",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +258,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
 
 [[package]]
 name = "either"
@@ -485,6 +500,7 @@ version = "0.1.2"
 dependencies = [
  "bstr",
  "criterion",
+ "ecow",
  "insta",
  "is_ci",
  "jiter",
@@ -493,6 +509,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "regex",
+ "rpds",
  "rstest",
  "serde",
  "serde_json",
@@ -926,6 +943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rpds"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f89f654d51fffdd6026289d07d1fd523244d46ae0a8bc22caa6dd7f9e8cb0b"
+dependencies = [
+ "archery",
+]
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1196,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -14,10 +14,13 @@ autotests = false
 
 [features]
 serde = ["dep:serde"]
+im = []
 
 [dependencies]
 memchr = { version = "2.7.5", default-features = false }
 bstr = { version = "1.12.0", default-features = false, features = ["alloc"] }
+ecow = "0.2"
+rpds = { version = "1", default-features = true }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 thiserror = { version = "2.0.16", default-features = false }
 
@@ -46,6 +49,20 @@ path = "tests/jsonmodem_values/mod.rs"
 [[test]]
 name = "fuzz_regressions"
 path = "tests/fuzz_regressions.rs"
+
+[[test]]
+name = "im_spikes"
+path = "tests/im_spikes.rs"
+
+[[test]]
+name = "im_adapter"
+path = "tests/im_adapter.rs"
+required-features = ["im"]
+
+[[example]]
+name = "im_snapshots"
+path = "examples/im_snapshots.rs"
+required-features = ["im"]
 
 [[example]]
 name = "profile_events"

--- a/crates/jsonmodem/benches/streaming_json_common.rs
+++ b/crates/jsonmodem/benches/streaming_json_common.rs
@@ -3,8 +3,8 @@
 #[path = "parse_partial_json_port.rs"]
 pub mod parse_partial_json_port;
 use jsonmodem::{
-    BufferOptions, JsonModem, JsonModemBuffers, JsonModemValues, ParserOptions, StdBackend,
-    lending_iterator::LendingIterator,
+    BufferOptions, ImBackend, ImValueAssembler, JsonModem, JsonModemBuffers, JsonModemValues,
+    ParserOptions, StdBackend, ValuesOptions, lending_iterator::LendingIterator,
 };
 
 pub fn produce_chunks(payload: &str, parts: usize) -> Vec<&str> {
@@ -59,9 +59,52 @@ pub fn run_jsonmodem_events(chunks: &[&str]) -> usize {
     events
 }
 
+pub fn run_jsonmodem_events_im(chunks: &[&str]) -> usize {
+    let mut parser = JsonModem::<ImBackend>::new(ParserOptions::default());
+    let mut events = 0usize;
+
+    for &chunk in chunks {
+        let mut iter = parser.feed(chunk);
+        while let Some(event) = iter.next() {
+            event.unwrap();
+            events += 1;
+        }
+    }
+
+    let mut iter = parser.finish();
+    while let Some(event) = iter.next() {
+        event.unwrap();
+        events += 1;
+    }
+
+    events
+}
+
 pub fn run_jsonmodem_buffers(chunks: &[&str]) -> usize {
     let mut parser =
         JsonModemBuffers::<StdBackend, _>::new(ParserOptions::default(), BufferOptions::default());
+    let mut events = 0usize;
+
+    for &chunk in chunks {
+        let mut iter = parser.feed(chunk);
+        while let Some(event) = iter.next() {
+            event.unwrap();
+            events += 1;
+        }
+    }
+
+    let mut iter = parser.finish();
+    while let Some(event) = iter.next() {
+        event.unwrap();
+        events += 1;
+    }
+
+    events
+}
+
+pub fn run_jsonmodem_buffers_im(chunks: &[&str]) -> usize {
+    let assembler = ImValueAssembler::new(BufferOptions::default());
+    let mut parser = JsonModemBuffers::with_builder(ParserOptions::default(), assembler);
     let mut events = 0usize;
 
     for &chunk in chunks {
@@ -98,6 +141,36 @@ pub fn run_jsonmodem_values(chunks: &[&str]) -> usize {
     let mut iter = parser.finish();
     while let Some(value) = LendingIterator::next(&mut iter) {
         let value = value.expect("values finish failure");
+        if value.is_final {
+            produced += 1;
+        }
+    }
+
+    produced
+}
+
+pub fn run_jsonmodem_values_im(chunks: &[&str]) -> usize {
+    let assembler = ImValueAssembler::new(BufferOptions::default());
+    let mut parser = JsonModemValues::with_buffer_builder(
+        ParserOptions::default(),
+        ValuesOptions::default(),
+        assembler,
+    );
+    let mut produced = 0usize;
+
+    for &chunk in chunks {
+        let mut iter = parser.feed(chunk);
+        while let Some(value) = LendingIterator::next(&mut iter) {
+            let value = value.expect("im values parse failure");
+            if value.is_final {
+                produced += 1;
+            }
+        }
+    }
+
+    let mut iter = parser.finish();
+    while let Some(value) = LendingIterator::next(&mut iter) {
+        let value = value.expect("im values finish failure");
         if value.is_final {
             produced += 1;
         }

--- a/crates/jsonmodem/benches/streaming_json_large.rs
+++ b/crates/jsonmodem/benches/streaming_json_large.rs
@@ -6,7 +6,8 @@ use std::{env, time::Duration};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use streaming_json_common::{
     produce_chunks, run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned,
-    run_jsonmodem_buffers, run_jsonmodem_events, run_jsonmodem_values, run_parse_partial_json,
+    run_jsonmodem_buffers, run_jsonmodem_buffers_im, run_jsonmodem_events, run_jsonmodem_events_im,
+    run_jsonmodem_values, run_jsonmodem_values_im, run_parse_partial_json,
 };
 
 fn bench_streaming_json_large(c: &mut Criterion) {
@@ -29,6 +30,14 @@ fn bench_streaming_json_large(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_events_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_events_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_buffers", parts),
             &parts,
             |b, &_p| {
@@ -37,10 +46,26 @@ fn bench_streaming_json_large(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_buffers_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_buffers_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_values", parts),
             &parts,
             |b, &_p| {
                 b.iter(|| run_jsonmodem_values(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_values_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_values_im(black_box(&chunks)));
             },
         );
 

--- a/crates/jsonmodem/benches/streaming_json_medium.rs
+++ b/crates/jsonmodem/benches/streaming_json_medium.rs
@@ -6,7 +6,8 @@ use std::{env, time::Duration};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use streaming_json_common::{
     produce_chunks, run_fix_json_parse, run_jiter_partial, run_jiter_partial_owned,
-    run_jsonmodem_buffers, run_jsonmodem_events, run_jsonmodem_values, run_parse_partial_json,
+    run_jsonmodem_buffers, run_jsonmodem_buffers_im, run_jsonmodem_events, run_jsonmodem_events_im,
+    run_jsonmodem_values, run_jsonmodem_values_im, run_parse_partial_json,
 };
 
 fn bench_streaming_json_medium(c: &mut Criterion) {
@@ -29,6 +30,14 @@ fn bench_streaming_json_medium(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_events_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_events_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_buffers", parts),
             &parts,
             |b, &_p| {
@@ -37,10 +46,26 @@ fn bench_streaming_json_medium(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_buffers_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_buffers_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_values", parts),
             &parts,
             |b, &_p| {
                 b.iter(|| run_jsonmodem_values(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_values_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_values_im(black_box(&chunks)));
             },
         );
 

--- a/crates/jsonmodem/benches/streaming_json_strategies.rs
+++ b/crates/jsonmodem/benches/streaming_json_strategies.rs
@@ -6,8 +6,8 @@ use std::{env, time::Duration};
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use streaming_json_common::{
     make_json_payload, produce_chunks, run_fix_json_parse, run_jiter_partial,
-    run_jiter_partial_owned, run_jsonmodem_buffers, run_jsonmodem_events, run_jsonmodem_values,
-    run_parse_partial_json,
+    run_jiter_partial_owned, run_jsonmodem_buffers, run_jsonmodem_buffers_im, run_jsonmodem_events,
+    run_jsonmodem_events_im, run_jsonmodem_values, run_jsonmodem_values_im, run_parse_partial_json,
 };
 
 fn bench_streaming_json_strategies(c: &mut Criterion) {
@@ -26,6 +26,14 @@ fn bench_streaming_json_strategies(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_events_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_events_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_buffers", parts),
             &parts,
             |b, &_p| {
@@ -34,10 +42,26 @@ fn bench_streaming_json_strategies(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new("jsonmodem_buffers_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_buffers_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new("jsonmodem_values", parts),
             &parts,
             |b, &_p| {
                 b.iter(|| run_jsonmodem_values(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_values_im", parts),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_values_im(black_box(&chunks)));
             },
         );
 

--- a/crates/jsonmodem/benches/streaming_parser.rs
+++ b/crates/jsonmodem/benches/streaming_parser.rs
@@ -7,7 +7,8 @@ mod streaming_json_common;
 
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use streaming_json_common::{
-    produce_chunks, run_jsonmodem_buffers, run_jsonmodem_events, run_jsonmodem_values,
+    produce_chunks, run_jsonmodem_buffers, run_jsonmodem_buffers_im, run_jsonmodem_events,
+    run_jsonmodem_events_im, run_jsonmodem_values, run_jsonmodem_values_im,
 };
 
 /// Produce a *deterministic* JSON document whose textual representation is at
@@ -50,6 +51,14 @@ fn bench_streaming_parser(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new(parts.to_string(), "jsonmodem_events_im"),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_events_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new(parts.to_string(), "jsonmodem_buffers"),
             &parts,
             |b, &_p| {
@@ -58,10 +67,26 @@ fn bench_streaming_parser(c: &mut Criterion) {
         );
 
         group.bench_with_input(
+            BenchmarkId::new(parts.to_string(), "jsonmodem_buffers_im"),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_buffers_im(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
             BenchmarkId::new(parts.to_string(), "jsonmodem_values"),
             &parts,
             |b, &_p| {
                 b.iter(|| run_jsonmodem_values(black_box(&chunks)));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new(parts.to_string(), "jsonmodem_values_im"),
+            &parts,
+            |b, &_p| {
+                b.iter(|| run_jsonmodem_values_im(black_box(&chunks)));
             },
         );
     }

--- a/crates/jsonmodem/examples/im_snapshots.rs
+++ b/crates/jsonmodem/examples/im_snapshots.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+
+#[cfg(feature = "im")]
+fn main() {
+    use jsonmodem::{JsonModemIm, ParserOptions, ValuesOptions};
+
+    let mut snapshots = JsonModemIm::with_options(
+        ParserOptions::default(),
+        ValuesOptions::default().with_partial(true),
+    );
+
+    let chunks = [
+        "{",
+        "\"title\":\"",
+        "he",
+        "llo\"",
+        ",\"active\":",
+        "true",
+        ",\"limits\":[",
+        "1,",
+        "2",
+        ",3],",
+        "\"metadata\":{",
+        "\"env\":\"",
+        "pr",
+        "od\"",
+        "}}",
+    ];
+
+    for chunk in &chunks {
+        for view in snapshots.feed(chunk) {
+            println!(
+                "partial index={} final={} value={}",
+                view.index, view.is_final, view.value
+            );
+        }
+    }
+
+    for view in snapshots.finish() {
+        println!(
+            "finish index={} final={} value={}",
+            view.index, view.is_final, view.value
+        );
+    }
+}
+
+#[cfg(not(feature = "im"))]
+fn main() {
+    eprintln!(
+        "Enable the `im` feature to run this example:\n  cargo run -p jsonmodem --features im --example im_snapshots"
+    );
+}

--- a/crates/jsonmodem/src/backend/im/mod.rs
+++ b/crates/jsonmodem/src/backend/im/mod.rs
@@ -1,11 +1,16 @@
+/// Immutable value definitions, zipper, and applicator for [`ImBackend`].
 pub mod value;
+/// Event-to-value applicator that builds immutable trees from parser events.
 pub mod value_applicator;
-pub mod value_tree;
+/// Persistent zipper utilities that mutate immutable values incrementally.
 pub mod value_zipper;
 
-use alloc::{borrow::Cow, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
+use alloc::{string::String, vec::Vec};
 use core::num::ParseFloatError;
 
+use rpds::Vector;
+
+pub use self::value::{Array, Map, Str};
 use self::{
     value::Value,
     value_applicator::{AppliedRef, ValueApplicator},
@@ -19,40 +24,33 @@ use crate::{
     },
     path::PathItem,
 };
-type StdBufferedEvent<'a> = BorrowedBufferedEvent<'a, StdBackend>;
 
-/// Context type for the Rust backend used by the JSON streaming parser.
-///
-/// It defines how strings are decoded from raw bytes and provides
-/// concrete types for path and event data emitted during parsing.
+pub type ImPath = Vector<PathItem>;
+type ImBufferedEvent<'a> = BorrowedBufferedEvent<'a, ImBackend>;
+
+/// Backend that builds immutable JSON values using persistent containers.
 #[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
-pub struct StdBackend {
+pub struct ImBackend {
     decode_mode: RustDecodeMode,
 }
 
+/// Modes controlling how raw string fragments are decoded for [`ImBackend`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-/// Modes for decoding raw bytes into strings.
 #[non_exhaustive]
 pub enum RustDecodeMode {
-    /// Strict UTF-8: invalid sequences are preserved only if already valid;
-    /// otherwise rejected.
     StrictUnicode,
-    /// Lossy decoding: invalid sequences are replaced (e.g., with the
-    /// replacement character).
     ReplaceInvalid,
 }
 
-impl Default for StdBackend {
+impl Default for ImBackend {
     fn default() -> Self {
-        Self {
-            decode_mode: RustDecodeMode::ReplaceInvalid,
-        }
+        Self::new()
     }
 }
 
-impl StdBackend {
-    /// Constructs a backend with the default lossy decoding strategy.
+impl ImBackend {
+    /// Creates a backend with lossy UTF-8 decoding for string fragments.
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -60,142 +58,123 @@ impl StdBackend {
         }
     }
 
-    /// Overrides the Unicode decoding mode used for raw string fragments.
+    /// Overrides the decode mode used when decoding raw string fragments.
     #[must_use]
     pub fn with_decode_mode(mut self, decode_mode: RustDecodeMode) -> Self {
         self.decode_mode = decode_mode;
         self
     }
 
-    /// Returns the configured decode mode.
+    /// Returns the active decode mode.
     #[must_use]
     pub fn decode_mode(&self) -> RustDecodeMode {
         self.decode_mode
     }
 }
 
-pub type StdPath = Vec<PathItem>;
+impl PathCtx for ImBackend {
+    type PathState = Vector<PathItem>;
+    type Path = ImPath;
 
-impl PathCtx for StdBackend {
-    type PathState = Vec<PathItem>;
-    type Path = StdPath;
-
-    #[inline]
     fn frozen_new(&mut self) -> Self::PathState {
-        Vec::new()
+        Vector::new()
     }
 
-    #[inline]
     fn thaw(&mut self, frozen: Self::PathState) -> Self::Path {
         frozen
     }
 
-    #[inline]
     fn freeze(&mut self, thawed: Self::Path) -> Self::PathState {
         thawed
     }
 
-    #[inline]
     fn push_key_from_str(&mut self, t: &mut Self::Path, key: &str) {
-        t.push(PathItem::Key(key.into()));
+        t.push_back_mut(PathItem::Key(key.into()));
     }
 
-    #[inline]
     fn push_index_zero(&mut self, t: &mut Self::Path) {
-        t.push(PathItem::Index(0));
+        t.push_back_mut(PathItem::Index(0));
     }
 
-    #[inline]
     fn bump_last_index(&mut self, t: &mut Self::Path) -> Result<(), PathError> {
-        let Some(PathItem::Index(i)) = t.last_mut() else {
+        let Some(last_index) = t.len().checked_sub(1) else {
             return Err(PathError::NotArrayFrame);
         };
-        *i += 1;
-        Ok(())
+        match t.get_mut(last_index) {
+            Some(PathItem::Index(index)) => {
+                *index += 1;
+                Ok(())
+            }
+            _ => Err(PathError::NotArrayFrame),
+        }
     }
 
-    #[inline]
     fn pop_kind(&mut self, t: &mut Self::Path) -> Option<PathKind> {
-        t.pop().map(
-            #[inline]
-            |item| match item {
-                PathItem::Key(_) => PathKind::Key,
-                PathItem::Index(_) => PathKind::Index,
-            },
-        )
+        let kind = t.last().map(|component| match component {
+            PathItem::Key(_) => PathKind::Key,
+            PathItem::Index(_) => PathKind::Index,
+        });
+        if kind.is_some() {
+            let _ = t.drop_last_mut();
+        }
+        kind
     }
 
-    #[inline]
     fn last_kind(&self, t: &Self::Path) -> Option<PathKind> {
-        t.last().map(
-            #[inline]
-            |item| match item {
-                PathItem::Key(_) => PathKind::Key,
-                PathItem::Index(_) => PathKind::Index,
-            },
-        )
+        t.last().map(|component| match component {
+            PathItem::Key(_) => PathKind::Key,
+            PathItem::Index(_) => PathKind::Index,
+        })
     }
 }
 
-impl ValueCtx for StdBackend {
+impl ValueCtx for ImBackend {
     type Null = ();
     type Bool = bool;
     type Num<'src> = f64;
-    type Str<'src> = Cow<'src, str>;
+    type Str<'src> = Str;
     type Value = Value;
 }
 
-impl EventCtx for StdBackend {
+impl EventCtx for ImBackend {
     type Error = ParseFloatError;
 
-    #[inline]
     fn push_key_from_raw_str(&mut self, t: &mut Self::Path, key: &[u8]) {
-        t.push(PathItem::Key(String::from_utf8_lossy(key).into()));
+        t.push_back_mut(PathItem::Key(String::from_utf8_lossy(key).into()));
     }
 
-    #[inline]
     fn new_null(&mut self) -> Result<Self::Null, Self::Error> {
         Ok(())
     }
 
-    #[inline]
     fn new_bool(&mut self, b: bool) -> Result<Self::Bool, Self::Error> {
         Ok(b)
     }
 
-    #[inline]
     fn new_number<'src>(&mut self, n: &'src str) -> Result<Self::Num<'src>, Self::Error> {
         n.parse()
     }
 
-    #[inline]
     fn new_number_owned<'a>(&mut self, n: String) -> Result<Self::Num<'a>, Self::Error> {
         n.parse()
     }
 
-    #[inline]
     fn new_str<'src>(&mut self, frag: &'src str) -> Result<Self::Str<'src>, Self::Error> {
-        Ok(Cow::Borrowed(frag))
+        Ok(Str::from(frag))
     }
 
-    #[inline]
     fn new_str_owned<'a>(&mut self, frag: String) -> Result<Self::Str<'a>, Self::Error> {
-        Ok(Cow::Owned(frag))
+        Ok(Str::from(frag))
     }
 
-    #[inline]
     fn new_str_raw_owned<'a>(&mut self, bytes: Vec<u8>) -> Result<Self::Str<'a>, Self::Error> {
         match self.decode_mode {
             RustDecodeMode::StrictUnicode => {
-                // In strict mode, reject non-UTF8 raw input.
-                // Parser should avoid calling this in strict mode; if it does,
-                // we still avoid panicking by producing an error-like lossy string.
                 let owned = String::from_utf8(bytes)
                     .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
-                Ok(Cow::Owned(owned))
+                Ok(Str::from(owned))
             }
             RustDecodeMode::ReplaceInvalid => {
-                // Decode lossily; special-case WTF-8 surrogate code units to U+FFFD.
                 let mut norm = Vec::with_capacity(bytes.len());
                 let mut i = 0;
                 while i < bytes.len() {
@@ -215,65 +194,64 @@ impl EventCtx for StdBackend {
                     Ok(s) => s,
                     Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
                 };
-                Ok(Cow::Owned(owned))
+                Ok(Str::from(owned))
             }
         }
     }
 }
 
-impl OwnedEventCtx for StdBackend {
+impl OwnedEventCtx for ImBackend {
     type OwnedNum = f64;
-    type OwnedStr = String;
+    type OwnedStr = Str;
 
-    #[inline]
     fn num_into_owned(n: Self::Num<'_>) -> Self::OwnedNum {
         n
     }
 
-    #[inline]
     fn str_into_owned(s: Self::Str<'_>) -> Self::OwnedStr {
-        s.into_owned()
+        s
     }
 }
 
-impl BuilderCtx for StdBackend {
-    type Array = Vec<Value>;
-    type Object = BTreeMap<Arc<str>, Value>;
+impl BuilderCtx for ImBackend {
+    type Array = Array;
+    type Object = Map;
 }
 
+/// String-buffering assembler for [`ImBackend`].
+#[allow(dead_code)]
 #[derive(Debug)]
-pub struct StdStringAssembler {
-    scratch: String,
+pub struct ImStringAssembler {
+    scratch: Str,
     options: BufferOptions,
 }
 
-impl StdStringAssembler {
-    #[inline]
+impl ImStringAssembler {
+    /// Creates a new assembler with the provided buffering options.
+    #[must_use]
     pub fn new(options: BufferOptions) -> Self {
         Self {
-            scratch: String::new(),
+            scratch: Str::default(),
             options,
         }
     }
 
-    #[inline]
+    /// Returns the configured buffering behaviour.
+    #[must_use]
     pub fn options(&self) -> BufferOptions {
         self.options
     }
 
-    #[inline]
-    fn string_value(&mut self, _is_final: bool) -> Cow<'_, str> {
-        // Always emit prefixes for the string-accumulating assembler.
-        Cow::Borrowed(self.scratch.as_str())
+    fn string_value(&self) -> Str {
+        self.scratch.clone()
     }
 }
 
-impl BufferAssembler<StdBackend> for StdStringAssembler {
-    #[inline]
+impl BufferAssembler<ImBackend> for ImStringAssembler {
     fn on_event<'a, 'src>(
         &'a mut self,
-        event: ParseEvent<'src, &'a StdPath, StdBackend>,
-    ) -> Result<StdBufferedEvent<'a>, ParseFloatError>
+        event: ParseEvent<'src, &'a ImPath, ImBackend>,
+    ) -> Result<ImBufferedEvent<'a>, ParseFloatError>
     where
         'src: 'a,
     {
@@ -291,7 +269,7 @@ impl BufferAssembler<StdBackend> for StdStringAssembler {
                     self.scratch.clear();
                 }
                 self.scratch.push_str(fragment.as_ref());
-                let value = Some(self.string_value(is_final));
+                let value = Some(self.string_value());
                 Ok(BufferedEvent::String {
                     path,
                     fragment,
@@ -308,31 +286,33 @@ impl BufferAssembler<StdBackend> for StdStringAssembler {
     }
 }
 
+/// Immutable value assembler built around rpds containers.
 #[derive(Debug)]
-pub struct StdValueAssembler {
+pub struct ImValueAssembler {
     applicator: ValueApplicator,
 }
 
-impl StdValueAssembler {
-    #[inline]
+impl ImValueAssembler {
+    /// Creates a new value assembler for the supplied buffering options.
+    #[must_use]
     pub fn new(options: BufferOptions) -> Self {
         Self {
             applicator: ValueApplicator::new(options),
         }
     }
 
-    #[inline]
+    /// Returns the current root value without consuming it.
+    #[must_use]
     pub fn read_root(&self) -> &Value {
         self.applicator.read_root()
     }
 
-    #[inline]
+    /// Consumes the accumulated root value, replacing it with `null`.
     pub fn take_root(&mut self) -> Value {
         self.applicator.take_root()
     }
 
-    #[inline]
-    fn map_scalar<'a>(path: &'a StdPath, leaf: &'a Value) -> StdBufferedEvent<'a> {
+    fn map_scalar<'a>(path: &'a ImPath, leaf: &'a Value) -> ImBufferedEvent<'a> {
         match leaf {
             Value::Null => BufferedEvent::Null { path },
             Value::Boolean(flag) => BufferedEvent::Boolean { path, value: *flag },
@@ -346,51 +326,45 @@ impl StdValueAssembler {
         }
     }
 
-    #[inline]
-    fn map_string<'a>(
-        path: &'a StdPath,
-        fragment: Cow<'a, str>,
+    fn map_string(
+        path: &ImPath,
+        fragment: Str,
         is_initial: bool,
         is_final: bool,
-        buffered: Option<&'a str>,
-    ) -> StdBufferedEvent<'a> {
+        buffered: Option<Str>,
+    ) -> ImBufferedEvent<'_> {
         BufferedEvent::String {
             path,
             fragment,
-            value: buffered.map(Cow::Borrowed),
+            value: buffered,
             is_initial,
             is_final,
         }
     }
 
-    #[inline]
-    fn map_array_begin(path: &StdPath) -> StdBufferedEvent<'_> {
+    fn map_array_begin(path: &ImPath) -> ImBufferedEvent<'_> {
         BufferedEvent::ArrayBegin { path }
     }
 
-    #[inline]
-    fn map_array_end<'a>(path: &'a StdPath, value: &'a Value) -> StdBufferedEvent<'a> {
+    fn map_array_end<'a>(path: &'a ImPath, value: &'a Value) -> ImBufferedEvent<'a> {
         BufferedEvent::ArrayEnd {
             path,
             value: value.as_array(),
         }
     }
 
-    #[inline]
-    fn map_object_begin(path: &StdPath) -> StdBufferedEvent<'_> {
+    fn map_object_begin(path: &ImPath) -> ImBufferedEvent<'_> {
         BufferedEvent::ObjectBegin { path }
     }
 
-    #[inline]
-    fn map_object_end<'a>(path: &'a StdPath, value: &'a Value) -> StdBufferedEvent<'a> {
+    fn map_object_end<'a>(path: &'a ImPath, value: &'a Value) -> ImBufferedEvent<'a> {
         BufferedEvent::ObjectEnd {
             path,
             value: value.as_object(),
         }
     }
 
-    #[inline]
-    fn map_event(applied: AppliedRef<'_>) -> StdBufferedEvent<'_> {
+    fn map_event(applied: AppliedRef<'_>) -> ImBufferedEvent<'_> {
         match applied {
             AppliedRef::Scalar { path, leaf } => Self::map_scalar(path, leaf),
             AppliedRef::String {
@@ -410,12 +384,11 @@ impl StdValueAssembler {
     }
 }
 
-impl BufferAssembler<StdBackend> for StdValueAssembler {
-    #[inline]
+impl BufferAssembler<ImBackend> for ImValueAssembler {
     fn on_event<'a, 'src>(
         &'a mut self,
-        event: ParseEvent<'src, &'a StdPath, StdBackend>,
-    ) -> Result<StdBufferedEvent<'a>, ParseFloatError>
+        event: ParseEvent<'src, &'a ImPath, ImBackend>,
+    ) -> Result<ImBufferedEvent<'a>, ParseFloatError>
     where
         'src: 'a,
     {
@@ -424,15 +397,11 @@ impl BufferAssembler<StdBackend> for StdValueAssembler {
     }
 }
 
-impl RootedBufferAssembler<StdBackend> for StdValueAssembler
+impl RootedBufferAssembler<ImBackend> for ImValueAssembler
 where
-    <StdBackend as PathCtx>::Path: crate::jsonmodem_buffers::PathRoot,
+    <ImBackend as PathCtx>::Path: crate::jsonmodem_buffers::PathRoot,
 {
-    #[inline]
     fn root(&self) -> &Value {
         self.read_root()
     }
 }
-
-#[allow(dead_code)]
-pub type StdBufferAssembler = StdValueAssembler;

--- a/crates/jsonmodem/src/backend/im/value.rs
+++ b/crates/jsonmodem/src/backend/im/value.rs
@@ -1,0 +1,199 @@
+use alloc::string::{String, ToString};
+use core::{fmt, fmt::Write as _};
+
+use ecow::EcoString;
+#[cfg(test)]
+use quickcheck::{Arbitrary, Gen};
+use rpds::{RedBlackTreeMapSync, VectorSync};
+
+/// Owned string type for the immutable backend (`EcoString` with COW
+/// semantics).
+pub type Str = EcoString;
+/// Default numeric representation (`f64`) used by the immutable backend.
+pub type Number = f64;
+/// Persistent vector storing array elements with structural sharing.
+pub type Array = VectorSync<Value>;
+/// Persistent red-black tree map storing object members keyed by `Str`.
+pub type Map = RedBlackTreeMapSync<Str, Value>;
+
+/// Immutable JSON value backed by persistent data structures.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Value {
+    /// JSON `null`.
+    Null,
+    /// JSON boolean.
+    Boolean(bool),
+    /// JSON number.
+    Number(Number),
+    /// JSON string.
+    String(Str),
+    /// JSON array.
+    Array(Array),
+    /// JSON object.
+    Object(Map),
+}
+
+impl Value {
+    /// Returns the boolean payload if this value is a `Boolean`.
+    #[must_use]
+    pub fn as_boolean(&self) -> Option<&bool> {
+        match self {
+            Self::Boolean(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns the numeric payload if this value is a `Number`.
+    #[must_use]
+    pub fn as_number(&self) -> Option<&Number> {
+        match self {
+            Self::Number(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns the string payload if this value is a `String`.
+    #[must_use]
+    pub fn as_string(&self) -> Option<&Str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns the array payload if this value is an `Array`.
+    #[must_use]
+    pub fn as_array(&self) -> Option<&Array> {
+        match self {
+            Self::Array(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// Returns the object payload if this value is an `Object`.
+    #[must_use]
+    pub fn as_object(&self) -> Option<&Map> {
+        match self {
+            Self::Object(map) => Some(map),
+            _ => None,
+        }
+    }
+}
+
+/// Writes a JSON string literal to `f`, escaping characters as needed.
+///
+/// # Errors
+///
+/// Returns any formatting error emitted by `f` while writing the escaped
+/// string.
+pub fn write_escaped_string(src: &str, f: &mut impl fmt::Write) -> fmt::Result {
+    for ch in src.chars() {
+        match ch {
+            '"' => f.write_str("\\\"")?,
+            '\\' => f.write_str("\\\\")?,
+            '\u{2028}' | '\u{2029}' => {
+                write!(f, "\\u{:04X}", ch as u32)?;
+            }
+            c if c.is_ascii_control() || (c.is_control() && (c as u32) <= 0xFFFF) => {
+                write!(f, "\\u{:04X}", c as u32)?;
+            }
+            _ => f.write_char(ch)?,
+        }
+    }
+    Ok(())
+}
+
+/// Returns a JSON-escaped string suitable for embedding in object keys.
+///
+/// # Panics
+///
+/// Panics only if writing to the internal buffer fails, which should be
+/// unreachable because `String`'s formatter implementations cannot error.
+#[must_use]
+pub fn escape_string(src: &str) -> String {
+    let mut escaped = String::with_capacity(src.len());
+    write_escaped_string(src, &mut escaped).expect("escape_string write failure");
+    escaped
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Null => f.write_str("null"),
+            Self::Boolean(value) => f.write_str(if *value { "true" } else { "false" }),
+            Self::Number(value) => f.write_str(&value.to_string()),
+            Self::String(value) => {
+                f.write_str("\"")?;
+                write_escaped_string(value, f)?;
+                f.write_char('"')
+            }
+            Self::Array(values) => {
+                f.write_str("[")?;
+                let mut first = true;
+                for value in values {
+                    if !first {
+                        f.write_str(",")?;
+                    }
+                    first = false;
+                    write!(f, "{value}")?;
+                }
+                f.write_str("]")
+            }
+            Self::Object(map) => {
+                f.write_str("{")?;
+                let mut first = true;
+                for (key, value) in map {
+                    if !first {
+                        f.write_str(",")?;
+                    }
+                    first = false;
+                    write!(f, "\"{}\":{value}", escape_string(key))?;
+                }
+                f.write_str("}")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+impl Arbitrary for Value {
+    fn arbitrary(g: &mut Gen) -> Self {
+        match usize::arbitrary(g) % 6 {
+            0 => Self::Null,
+            1 => Self::Boolean(bool::arbitrary(g)),
+            2 => {
+                let mut number = f64::arbitrary(g);
+                while !number.is_finite() {
+                    number = f64::arbitrary(g);
+                }
+                number = number.rem_euclid(1_000_000.0);
+                Self::Number(number)
+            }
+            3 => Self::String(random_ascii_string(g).as_str().into()),
+            4 => {
+                let len = usize::arbitrary(g) % 4;
+                let mut items = Array::new_sync();
+                for _ in 0..len {
+                    items.push_back_mut(Self::arbitrary(g));
+                }
+                Self::Array(items)
+            }
+            _ => {
+                let len = usize::arbitrary(g) % 4;
+                let mut map = Map::new_sync();
+                for _ in 0..len {
+                    map.insert_mut(Str::from(random_ascii_string(g)), Self::arbitrary(g));
+                }
+                Self::Object(map)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn random_ascii_string(g: &mut Gen) -> String {
+    let len = usize::arbitrary(g) % 20;
+    (0..len)
+        .map(|_| char::from(b'_' + (u8::arbitrary(g) % (b'z' - b'_'))))
+        .collect()
+}

--- a/crates/jsonmodem/src/backend/im/value_applicator.rs
+++ b/crates/jsonmodem/src/backend/im/value_applicator.rs
@@ -5,13 +5,11 @@
     dead_code
 )]
 
-use alloc::{
-    borrow::{Cow, ToOwned},
-    collections::BTreeMap,
-    vec::Vec,
+use super::{
+    ImBackend, ImPath,
+    value::{Array, Map, Str, Value},
+    value_zipper::ValueZipper,
 };
-
-use super::{StdBackend, StdPath, value::Value, value_zipper::ValueZipper};
 #[cfg(debug_assertions)]
 use crate::backend::TransitionAsserter;
 use crate::{
@@ -22,32 +20,32 @@ use crate::{
 
 pub enum AppliedRef<'a> {
     Scalar {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
     },
     String {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
-        fragment: Cow<'a, str>,
+        fragment: Str,
         is_initial: bool,
         is_final: bool,
-        buffered: Option<&'a str>,
+        buffered: Option<Str>,
     },
     ArrayBegin {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
     },
     ArrayEnd {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
         root_completed: bool,
     },
     ObjectBegin {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
     },
     ObjectEnd {
-        path: &'a StdPath,
+        path: &'a ImPath,
         leaf: &'a Value,
         root_completed: bool,
     },
@@ -64,7 +62,6 @@ pub struct ValueApplicator {
 }
 
 impl ValueApplicator {
-    #[inline]
     pub fn new(options: BufferOptions) -> Self {
         Self {
             zipper: ValueZipper::new(),
@@ -75,10 +72,9 @@ impl ValueApplicator {
         }
     }
 
-    #[inline]
     pub fn push<'a, 'src>(
         &'a mut self,
-        event: &ParseEvent<'src, &'a StdPath, StdBackend>,
+        event: &ParseEvent<'src, &'a ImPath, ImBackend>,
     ) -> AppliedRef<'a>
     where
         'src: 'a,
@@ -91,15 +87,15 @@ impl ValueApplicator {
         let applied = match event {
             ParseEvent::Null { path } => {
                 let path = *path;
-                self.apply_scalar(&path, Value::Null)
+                self.apply_scalar(path, Value::Null)
             }
             ParseEvent::Boolean { path, value } => {
                 let path = *path;
-                self.apply_scalar(&path, Value::Boolean(*value))
+                self.apply_scalar(path, Value::Boolean(*value))
             }
             ParseEvent::Number { path, value } => {
                 let path = *path;
-                self.apply_scalar(&path, Value::Number(*value))
+                self.apply_scalar(path, Value::Number(*value))
             }
             ParseEvent::String {
                 path,
@@ -108,7 +104,6 @@ impl ValueApplicator {
                 is_final,
             } => {
                 let path = *path;
-                let fragment = fragment.clone();
                 match outcome.transition {
                     RootTransition::AppendString { .. }
                     | RootTransition::StartRootScalar
@@ -120,37 +115,23 @@ impl ValueApplicator {
                         debug_assert!(false, "unexpected transition for string event");
                     }
                 }
-                self.apply_string(&path, fragment, *is_initial, *is_final)
+                self.apply_string(path, fragment.clone(), *is_initial, *is_final)
             }
             ParseEvent::ArrayBegin { path } => {
                 let path = *path;
-                debug_assert!(matches!(
-                    outcome.transition,
-                    RootTransition::PushArray
-                        | RootTransition::StayArray { .. }
-                        | RootTransition::StayObject { .. }
-                ));
-                self.apply_container_begin(&path, ContainerKind::Array)
+                self.apply_container_begin(path, ContainerKind::Array)
             }
             ParseEvent::ArrayEnd { path } => {
                 let path = *path;
-                debug_assert!(matches!(outcome.transition, RootTransition::PopContainer));
-                self.apply_container_end(&path, ContainerKind::Array)
+                self.apply_container_end(path, ContainerKind::Array)
             }
             ParseEvent::ObjectBegin { path } => {
                 let path = *path;
-                debug_assert!(matches!(
-                    outcome.transition,
-                    RootTransition::PushObject
-                        | RootTransition::StayObject { .. }
-                        | RootTransition::StayArray { .. }
-                ));
-                self.apply_container_begin(&path, ContainerKind::Object)
+                self.apply_container_begin(path, ContainerKind::Object)
             }
             ParseEvent::ObjectEnd { path } => {
                 let path = *path;
-                debug_assert!(matches!(outcome.transition, RootTransition::PopContainer));
-                self.apply_container_end(&path, ContainerKind::Object)
+                self.apply_container_end(path, ContainerKind::Object)
             }
         };
 
@@ -159,50 +140,38 @@ impl ValueApplicator {
         applied
     }
 
-    #[inline]
     pub fn read_root(&self) -> &Value {
         self.zipper.read_root()
     }
 
-    #[inline]
     pub fn take_root(&mut self) -> Value {
         self.zipper.take_root()
     }
 
-    #[inline]
     pub fn options(&self) -> BufferOptions {
         self.options
     }
 
-    #[inline]
-    fn apply_scalar<'a>(&'a mut self, path: &StdPath, value: Value) -> AppliedRef<'a> {
+    fn apply_scalar<'a>(&'a mut self, path: &'a ImPath, value: Value) -> AppliedRef<'a> {
         let (path, leaf) = self.zipper.with_leaf_mut(path, |slot| *slot = value);
         AppliedRef::Scalar { path, leaf }
     }
 
-    #[inline]
     fn apply_string<'a>(
         &'a mut self,
-        path: &StdPath,
-        fragment: Cow<'a, str>,
+        path: &'a ImPath,
+        fragment: Str,
         is_initial: bool,
         is_final: bool,
     ) -> AppliedRef<'a> {
-        let fragment_ref = fragment.as_ref();
-
         let (path, leaf) = self.zipper.with_leaf_mut(path, |slot| match slot {
-            Value::String(existing) => {
-                if is_initial {
-                    existing.clear();
-                }
-                existing.push_str(fragment_ref);
+            Value::String(existing) if !is_initial => {
+                existing.push_str(fragment.as_ref());
             }
             _ => {
-                *slot = Value::String(fragment_ref.to_owned());
+                *slot = Value::String(fragment.clone());
             }
         });
-
-        let buffered = None;
 
         AppliedRef::String {
             path,
@@ -210,20 +179,19 @@ impl ValueApplicator {
             fragment,
             is_initial,
             is_final,
-            buffered,
+            buffered: None,
         }
     }
 
-    #[inline]
     fn apply_container_begin<'a>(
         &'a mut self,
-        path: &StdPath,
+        path: &'a ImPath,
         kind: ContainerKind,
     ) -> AppliedRef<'a> {
         let (path, leaf) = self.zipper.with_leaf_mut(path, |slot| {
             *slot = match kind {
-                ContainerKind::Array => Value::Array(Vec::new()),
-                ContainerKind::Object => Value::Object(BTreeMap::default()),
+                ContainerKind::Array => Value::Array(Array::new_sync()),
+                ContainerKind::Object => Value::Object(Map::new_sync()),
             };
         });
 
@@ -233,10 +201,9 @@ impl ValueApplicator {
         }
     }
 
-    #[inline]
     fn apply_container_end<'a>(
         &'a mut self,
-        path: &StdPath,
+        path: &'a ImPath,
         kind: ContainerKind,
     ) -> AppliedRef<'a> {
         let (path, leaf) = self.zipper.with_leaf(path);

--- a/crates/jsonmodem/src/backend/im/value_zipper.rs
+++ b/crates/jsonmodem/src/backend/im/value_zipper.rs
@@ -1,0 +1,117 @@
+use alloc::sync::Arc;
+
+use super::{
+    ImPath,
+    value::{Array, Map, Str, Value},
+};
+use crate::path::PathItem;
+
+#[derive(Debug)]
+pub struct ValueZipper {
+    root: Value,
+}
+
+impl ValueZipper {
+    pub fn new() -> Self {
+        Self { root: Value::Null }
+    }
+
+    pub fn take_root(&mut self) -> Value {
+        core::mem::replace(&mut self.root, Value::Null)
+    }
+
+    pub fn read_root(&self) -> &Value {
+        &self.root
+    }
+
+    pub fn with_leaf_mut<'a, F>(
+        &'a mut self,
+        path: &'a ImPath,
+        mutate: F,
+    ) -> (&'a ImPath, &'a Value)
+    where
+        F: FnOnce(&mut Value),
+    {
+        let slot = align_path(&mut self.root, path);
+        mutate(slot);
+        let leaf: &Value = slot;
+        (path, leaf)
+    }
+
+    pub fn with_leaf<'a>(&'a mut self, path: &'a ImPath) -> (&'a ImPath, &'a Value) {
+        let slot = align_path(&mut self.root, path) as *mut Value;
+        let leaf = unsafe { &*slot };
+        (path, leaf)
+    }
+}
+
+impl Default for ValueZipper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn ensure_array(value: &mut Value) -> &mut Array {
+    if !matches!(value, Value::Array(_)) {
+        *value = Value::Array(Array::new_sync());
+    }
+
+    match value {
+        Value::Array(array) => array,
+        _ => unreachable!(),
+    }
+}
+
+fn ensure_array_index(array: &mut Array, index: usize) -> &mut Value {
+    let mut len = array.len();
+    while len <= index {
+        array.push_back_mut(Value::Null);
+        len += 1;
+    }
+
+    array
+        .get_mut(index)
+        .unwrap_or_else(|| panic!("index ensured but missing: {index}"))
+}
+
+fn ensure_object(value: &mut Value) -> &mut Map {
+    if !matches!(value, Value::Object(_)) {
+        *value = Value::Object(Map::new_sync());
+    }
+
+    match value {
+        Value::Object(map) => map,
+        _ => unreachable!(),
+    }
+}
+
+fn ensure_object_key<'a>(map: &'a mut Map, key: &Arc<str>) -> &'a mut Value {
+    let key_str: &str = key.as_ref();
+    if map.contains_key(key_str) {
+        map.get_mut(key_str)
+            .expect("key exists but could not be fetched mutably")
+    } else {
+        map.insert_mut(Str::from(key_str), Value::Null);
+        map.get_mut(key_str)
+            .expect("key inserted but missing from map")
+    }
+}
+
+fn align_path<'a>(root: &'a mut Value, path: &ImPath) -> &'a mut Value {
+    let mut current = root;
+
+    for component in path {
+        match component {
+            PathItem::Index(index) => {
+                let array = ensure_array(current);
+                current = ensure_array_index(array, *index);
+            }
+            PathItem::Key(key) => {
+                let map = ensure_object(current);
+                current = ensure_object_key(map, key);
+            }
+        }
+    }
+
+    current
+}

--- a/crates/jsonmodem/src/backend/mod.rs
+++ b/crates/jsonmodem/src/backend/mod.rs
@@ -1,3 +1,4 @@
+mod im;
 pub mod raw;
 mod std;
 
@@ -8,7 +9,6 @@ pub(crate) use transition_debug::TransitionAsserter;
 
 #[cfg(not(any(fuzzing, debug_assertions)))]
 mod transition_debug {
-    use alloc::vec::Vec;
     use core::fmt::Debug;
 
     use crate::{context::ValueCtx, event::ParseEvent, path::PathItem};
@@ -23,10 +23,13 @@ mod transition_debug {
             Self
         }
 
-        pub(crate) fn observe<K: Debug, Backend: ValueCtx>(
+        pub(crate) fn observe<K: Debug, Backend: ValueCtx, P>(
             &mut self,
-            _event: &ParseEvent<'_, &'_ Vec<PathItem<K, usize>>, Backend>,
-        ) {
+            _event: &ParseEvent<'_, &'_ P, Backend>,
+        ) where
+            for<'a> &'a P: IntoIterator<Item = &'a PathItem<K, usize>>,
+            P: Debug,
+        {
         }
     }
 }
@@ -36,6 +39,8 @@ mod zipper_transition;
 pub use raw::RawContext;
 pub(crate) use zipper_transition::{ParserCursor, RootTransition};
 
+#[allow(unused_imports)]
+pub use self::im::{ImBackend, ImPath, ImStringAssembler, ImValueAssembler, value as im_value};
 #[allow(unused_imports)]
 pub use self::std::{
     StdBackend, StdBufferAssembler, StdPath, StdStringAssembler, StdValueAssembler, value,

--- a/crates/jsonmodem/src/backend/raw.rs
+++ b/crates/jsonmodem/src/backend/raw.rs
@@ -266,7 +266,7 @@ impl BufferAssembler<RawContext> for RawBufferAssembler {
             }
             ParseEvent::String {
                 path,
-                fragment,
+                ref fragment,
                 is_initial,
                 is_final,
             } => {
@@ -281,7 +281,7 @@ impl BufferAssembler<RawContext> for RawBufferAssembler {
                 let fragment_text = String::from_utf8_lossy(fragment.as_ref()).into_owned();
                 self.values.append_string(&canonical, &fragment_text);
                 let buffered = self.update_string_value(&canonical, &fragment_text, is_final);
-                let fragment_owned = Cow::Owned(fragment.into_owned());
+                let fragment_owned = Cow::Owned(fragment.clone().into_owned());
                 let value = Some(Cow::Owned(buffered.into_bytes()));
                 Ok(BufferedEvent::String {
                     path,

--- a/crates/jsonmodem/src/backend/transition_debug.rs
+++ b/crates/jsonmodem/src/backend/transition_debug.rs
@@ -14,45 +14,50 @@ impl TransitionAsserter {
         Self::default()
     }
 
-    pub(crate) fn observe<K: Debug, Backend: ValueCtx>(
-        &mut self,
-        event: &ParseEvent<'_, &'_ Vec<PathItem<K, usize>>, Backend>,
-    ) {
-        let (path, kind) = match event {
+    pub(crate) fn observe<K, Backend, P>(&mut self, event: &ParseEvent<'_, &'_ P, Backend>)
+    where
+        K: Debug,
+        Backend: ValueCtx,
+        for<'a> &'a P: IntoIterator<Item = &'a PathItem<K, usize>>,
+        P: Debug,
+    {
+        let (slots, kind) = match event {
             ParseEvent::Null { path }
             | ParseEvent::Boolean { path, .. }
-            | ParseEvent::Number { path, .. } => (path.as_slice(), EventKind::Scalar),
+            | ParseEvent::Number { path, .. } => (Self::slots_from_path(path), EventKind::Scalar),
             ParseEvent::String {
                 path,
                 is_initial,
                 is_final,
                 ..
             } => (
-                path.as_slice(),
+                Self::slots_from_path(path),
                 EventKind::String {
                     is_initial: *is_initial,
                     is_final: *is_final,
                 },
             ),
-            ParseEvent::ArrayBegin { path } => (path.as_slice(), EventKind::ArrayBegin),
-            ParseEvent::ArrayEnd { path } => (path.as_slice(), EventKind::ArrayEnd),
-            ParseEvent::ObjectBegin { path } => (path.as_slice(), EventKind::ObjectBegin),
-            ParseEvent::ObjectEnd { path } => (path.as_slice(), EventKind::ObjectEnd),
+            ParseEvent::ArrayBegin { path } => (Self::slots_from_path(path), EventKind::ArrayBegin),
+            ParseEvent::ArrayEnd { path } => (Self::slots_from_path(path), EventKind::ArrayEnd),
+            ParseEvent::ObjectBegin { path } => {
+                (Self::slots_from_path(path), EventKind::ObjectBegin)
+            }
+            ParseEvent::ObjectEnd { path } => (Self::slots_from_path(path), EventKind::ObjectEnd),
         };
 
-        self.observe_path(path, kind);
+        self.observe_slots(slots, kind);
     }
 
-    fn observe_path<K>(&mut self, path: &[PathItem<K, usize>], kind: EventKind) {
-        let slots = path
-            .iter()
+    fn slots_from_path<K, P>(path: &P) -> Vec<PathSlot>
+    where
+        for<'a> &'a P: IntoIterator<Item = &'a PathItem<K, usize>>,
+    {
+        path.into_iter()
             .map(|component| match component {
                 PathItem::Key(_) => PathSlot::Key,
                 PathItem::Index(index) => PathSlot::Index(*index),
             })
-            .collect::<Vec<_>>();
-
-        self.observe_slots(slots, kind);
+            .collect()
     }
 
     fn observe_slots(&mut self, path: Vec<PathSlot>, kind: EventKind) {

--- a/crates/jsonmodem/src/backend/zipper_transition.rs
+++ b/crates/jsonmodem/src/backend/zipper_transition.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 use core::fmt::Debug;
 
+use rpds::Vector;
+
 use crate::{context::ValueCtx, event::ParseEvent, path::PathItem};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -27,21 +29,74 @@ pub struct ParserCursor {
     previous_depth: usize,
 }
 
+pub trait ParserPath<K> {
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn last(&self) -> Option<&PathItem<K, usize>>;
+}
+
+impl<K> ParserPath<K> for Vec<PathItem<K, usize>> {
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        Vec::is_empty(self)
+    }
+
+    fn last(&self) -> Option<&PathItem<K, usize>> {
+        self.as_slice().last()
+    }
+}
+
+impl<K> ParserPath<K> for Vector<PathItem<K, usize>> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn last(&self) -> Option<&PathItem<K, usize>> {
+        self.last()
+    }
+}
+
+impl<K, T> ParserPath<K> for &T
+where
+    T: ParserPath<K> + ?Sized,
+{
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn is_empty(&self) -> bool {
+        (**self).is_empty()
+    }
+
+    fn last(&self) -> Option<&PathItem<K, usize>> {
+        (**self).last()
+    }
+}
+
 impl ParserCursor {
     pub fn new() -> Self {
         Self::default()
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn classify_transition<'path, K, Backend>(
+    pub fn classify_transition<'src, 'path, K, Backend, P>(
         &mut self,
-        event: &ParseEvent<'_, &'path Vec<PathItem<K, usize>>, Backend>,
+        event: &'path ParseEvent<'src, &'path P, Backend>,
     ) -> TransitionOutcome<'path, K>
     where
+        'src: 'path,
         K: 'path + Debug,
         Backend: ValueCtx,
+        P: ParserPath<K> + Debug,
     {
-        let path = event.path().as_slice();
+        let path = event.path();
         let depth = path.len();
         #[cfg(any(debug_assertions, fuzzing))]
         {
@@ -68,9 +123,8 @@ impl ParserCursor {
                 is_final,
                 ..
             } => {
-                let path_slice = path.as_slice();
                 if *is_initial {
-                    let outcome = self.scalar_transition(path_slice);
+                    let outcome = self.scalar_transition(path);
                     self.string_in_progress = !*is_final;
                     TransitionOutcome {
                         completes_array_slot: outcome.completes_array_slot && *is_final,
@@ -87,7 +141,7 @@ impl ParserCursor {
                         transition: RootTransition::AppendString {
                             is_final: *is_final,
                         },
-                        completes_array_slot: path_slice
+                        completes_array_slot: path
                             .last()
                             .is_some_and(|item| matches!(item, PathItem::Index(_)))
                             && *is_final,
@@ -97,11 +151,10 @@ impl ParserCursor {
             ParseEvent::ArrayBegin { path } => {
                 self.string_in_progress = false;
                 let completes_array_slot = false;
-                let path_slice = path.as_slice();
-                let transition = if path_slice.is_empty() {
+                let transition = if path.is_empty() {
                     RootTransition::PushArray
                 } else {
-                    match path_slice
+                    match path
                         .last()
                         .expect("non-empty path must have a final component")
                     {
@@ -112,7 +165,7 @@ impl ParserCursor {
 
                 self.frames.push(FrameContext {
                     kind: ContainerKind::Array,
-                    parent_is_array: path_slice
+                    parent_is_array: path
                         .last()
                         .is_some_and(|item| matches!(item, PathItem::Index(_))),
                 });
@@ -125,11 +178,10 @@ impl ParserCursor {
             ParseEvent::ObjectBegin { path } => {
                 self.string_in_progress = false;
                 let completes_array_slot = false;
-                let path_slice = path.as_slice();
-                let transition = if path_slice.is_empty() {
+                let transition = if path.is_empty() {
                     RootTransition::PushObject
                 } else {
-                    match path_slice
+                    match path
                         .last()
                         .expect("non-empty path must have a final component")
                     {
@@ -140,7 +192,7 @@ impl ParserCursor {
 
                 self.frames.push(FrameContext {
                     kind: ContainerKind::Object,
-                    parent_is_array: path_slice
+                    parent_is_array: path
                         .last()
                         .is_some_and(|item| matches!(item, PathItem::Index(_))),
                 });
@@ -155,10 +207,10 @@ impl ParserCursor {
         }
     }
 
-    fn scalar_transition<'path, K>(
-        &mut self,
-        path: &'path [PathItem<K, usize>],
-    ) -> TransitionOutcome<'path, K> {
+    fn scalar_transition<'path, K, P>(&mut self, path: &'path P) -> TransitionOutcome<'path, K>
+    where
+        P: ParserPath<K>,
+    {
         self.string_in_progress = false;
         if path.is_empty() {
             TransitionOutcome {

--- a/crates/jsonmodem/src/jsonmodem_buffers.rs
+++ b/crates/jsonmodem/src/jsonmodem_buffers.rs
@@ -2,6 +2,8 @@
 
 use alloc::vec::Vec;
 
+use rpds::Vector;
+
 use crate::{
     buffer_options::BufferOptions,
     context::{BuilderCtx, EventCtx, OwnedEventCtx, PathCtx},
@@ -162,6 +164,12 @@ impl<T: PathRoot + ?Sized> PathRoot for &T {
 }
 
 impl<K, I> PathRoot for Vec<PathItem<K, I>> {
+    fn is_root(&self) -> bool {
+        self.is_empty()
+    }
+}
+
+impl<K, I> PathRoot for Vector<PathItem<K, I>> {
     fn is_root(&self) -> bool {
         self.is_empty()
     }

--- a/crates/jsonmodem/src/jsonmodem_im.rs
+++ b/crates/jsonmodem/src/jsonmodem_im.rs
@@ -1,0 +1,214 @@
+//! Immutable snapshot adapter built on top of [`ImBackend`].
+//!
+//! Enable the `im` Cargo feature to opt into immutable snapshots that reuse
+//! persistent data structures (`EcoString`, `rpds`) instead of cloning `String`
+//! or `Vec` values. `JsonModemIm` wraps [`JsonModemValues`] and records each
+//! completed root so callers can iterate over [`StreamingValue`] instances
+//! without juggling lifetimes. This is ideal when you want deterministic
+//! snapshots (e.g. logging, caching, or diffing) while still feeding the parser
+//! in streaming chunks.
+//!
+//! The immutable backend differs from [`JsonModemValues`] in one key way: the
+//! iterators returned by [`feed`](JsonModemIm::feed) and
+//! [`finish`](JsonModemIm::finish) yield owned values, not borrowed snapshots.
+//! Because the underlying data structures are persistent, cloning a completed
+//! value is cheap, which allows us to expose a standard iterator API that
+//! callers can move across threads or stash for later use.
+//!
+//! ```rust
+//! # #[cfg(feature = "im")]
+//! # {
+//! use jsonmodem::{JsonModemIm, ParserOptions, ValuesOptions};
+//!
+//! let mut snapshots = JsonModemIm::with_options(
+//!     ParserOptions::default(),
+//!     ValuesOptions::default().with_partial(true),
+//! );
+//!
+//! for view in snapshots.feed("{\"title\":\"he") {
+//!     println!("partial: {}", view.value);
+//! }
+//! for view in snapshots.feed("llo\",\"active\":true}") {
+//!     println!("partial: {}", view.value);
+//! }
+//! for view in snapshots.finish() {
+//!     if view.is_final {
+//!         println!("final: {}", view.value);
+//!     }
+//! }
+//! # }
+//! ```
+//!
+//! The adapter shares the same parser and buffering machinery as the standard
+//! backend, so benchmarks and `QuickCheck` suites that exercise
+//! `JsonModemValues` automatically cover the immutable path as well.
+
+use crate::{
+    ImBackend, ImValueAssembler, JsonModemValues, ParserOptions, StreamingValue, ValuesOptions,
+    buffer_options::BufferOptions,
+    im_value,
+    jsonmodem_values::{JsonModemValuesClosed, JsonModemValuesIter, ValuesError},
+};
+
+/// Immutable snapshot adapter that exposes persistent JSON roots via standard
+/// iterators.
+///
+/// `JsonModemIm` wraps [`JsonModemValues`] configured with [`ImBackend`]. Each
+/// call to [`feed`](Self::feed) or [`finish`](Self::finish) clones any
+/// completed values into persistent structures so callers can hold or move them
+/// without borrow checker constraints.
+pub struct JsonModemIm {
+    values: Option<JsonModemValues<ImBackend, ImValueAssembler>>,
+}
+
+impl Default for JsonModemIm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JsonModemIm {
+    /// Creates a snapshot adapter with default parser and buffering options.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_config(
+            ParserOptions::default(),
+            ValuesOptions::default(),
+            BufferOptions::default(),
+        )
+    }
+
+    /// Builds a snapshot adapter with explicit parser and values configuration.
+    #[must_use]
+    pub fn with_options(parser: ParserOptions, values: ValuesOptions) -> Self {
+        Self::with_config(parser, values, BufferOptions::default())
+    }
+
+    /// Builds a snapshot adapter with explicit parser, values, and buffering
+    /// options.
+    #[must_use]
+    pub fn with_config(
+        parser: ParserOptions,
+        values: ValuesOptions,
+        buffers: BufferOptions,
+    ) -> Self {
+        let assembler = ImValueAssembler::new(buffers);
+        let parser = parser.with_allow_multiple_json_values(true);
+        let inner = JsonModemValues::with_buffer_builder(parser, values, assembler);
+        Self {
+            values: Some(inner),
+        }
+    }
+
+    /// Returns `true` once [`finish`](Self::finish) has been called.
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        self.values.is_none()
+    }
+
+    /// Feeds a chunk of JSON and returns an iterator over the newly produced
+    /// snapshots.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`finish`](Self::finish) has already been invoked.
+    #[must_use]
+    pub fn feed<'a>(&'a mut self, chunk: &'a str) -> JsonModemImIter<'a> {
+        let values = self
+            .values
+            .as_mut()
+            .expect("JsonModemIm::feed called after finish");
+        JsonModemImIter {
+            inner: values.feed(chunk),
+        }
+    }
+
+    /// Completes parsing and yields any remaining snapshots.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once.
+    #[must_use]
+    pub fn finish(&mut self) -> JsonModemImClosed {
+        let values = self
+            .values
+            .take()
+            .expect("JsonModemIm::finish called more than once");
+        JsonModemImClosed {
+            inner: values.finish(),
+        }
+    }
+}
+
+/// Iterator over immutable snapshots produced by [`JsonModemIm`].
+pub struct JsonModemImIter<'a> {
+    inner: JsonModemValuesIter<'a, ImBackend, ImValueAssembler>,
+}
+
+impl Iterator for JsonModemImIter<'_> {
+    type Item = StreamingValue<im_value::Value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|result| result.expect("JsonModemIm iterator error"))
+    }
+}
+
+impl<'a> JsonModemImIter<'a> {
+    /// Returns an iterator yielding [`Result`] if the caller prefers explicit
+    /// error handling.
+    #[must_use]
+    pub fn into_results(self) -> JsonModemImResultIter<'a> {
+        JsonModemImResultIter { inner: self.inner }
+    }
+}
+
+/// Iterator yielding [`Result`] values for immutable snapshots.
+pub struct JsonModemImResultIter<'a> {
+    inner: JsonModemValuesIter<'a, ImBackend, ImValueAssembler>,
+}
+
+impl Iterator for JsonModemImResultIter<'_> {
+    type Item = Result<StreamingValue<im_value::Value>, ValuesError<ImBackend>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+/// Iterator returned after [`JsonModemIm::finish`].
+pub struct JsonModemImClosed {
+    inner: JsonModemValuesClosed<ImBackend, ImValueAssembler>,
+}
+
+impl Iterator for JsonModemImClosed {
+    type Item = StreamingValue<im_value::Value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|result| result.expect("JsonModemIm finish iterator error"))
+    }
+}
+
+impl JsonModemImClosed {
+    /// Returns an iterator yielding [`Result`] values for callers that prefer
+    /// explicit error handling.
+    #[must_use]
+    pub fn into_results(self) -> JsonModemImClosedResultIter {
+        JsonModemImClosedResultIter { inner: self.inner }
+    }
+}
+
+/// Result iterator returned after [`JsonModemIm::finish`].
+pub struct JsonModemImClosedResultIter {
+    inner: JsonModemValuesClosed<ImBackend, ImValueAssembler>,
+}
+
+impl Iterator for JsonModemImClosedResultIter {
+    type Item = Result<StreamingValue<im_value::Value>, ValuesError<ImBackend>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}

--- a/crates/jsonmodem/src/jsonmodem_values.rs
+++ b/crates/jsonmodem/src/jsonmodem_values.rs
@@ -49,7 +49,8 @@ pub enum ValuesError<Ctx: EventCtx> {
 /// High-level adapter that maps streaming events to root values.
 pub struct JsonModemValues<Ctx = StdBackend, A = StdValueAssembler>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx + Default,
+    Ctx: BuilderCtx + EventCtx + Default,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -83,7 +84,8 @@ where
 
 impl<Ctx, A> JsonModemValues<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx + Default,
+    Ctx: BuilderCtx + EventCtx + Default,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -125,7 +127,8 @@ where
 /// Lending iterator yielding streaming value references.
 pub struct JsonModemValuesIter<'a, Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -136,7 +139,8 @@ where
 
 impl<Ctx, A> JsonModemValuesIter<'_, Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -147,18 +151,19 @@ where
     #[allow(clippy::wrong_self_convention)]
     pub fn to_iter(
         mut self,
-    ) -> impl Iterator<Item = Result<StreamingValue<Value>, ValuesError<Ctx>>> {
+    ) -> impl Iterator<Item = Result<StreamingValue<Ctx::Value>, ValuesError<Ctx>>> {
         core::iter::from_fn(move || Iterator::next(&mut self))
     }
 }
 
 impl<Ctx, A> Iterator for JsonModemValuesIter<'_, Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
-    type Item = Result<StreamingValue<Value>, ValuesError<Ctx>>;
+    type Item = Result<StreamingValue<Ctx::Value>, ValuesError<Ctx>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_value_ref().map(clone_streaming_value)
@@ -167,7 +172,8 @@ where
 
 impl<Ctx, A> LendingIterator for JsonModemValuesIter<'_, Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -184,7 +190,8 @@ where
 /// Iterator draining remaining values after finishing the stream.
 pub struct JsonModemValuesClosed<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -195,7 +202,8 @@ where
 
 impl<Ctx, A> JsonModemValuesClosed<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -206,18 +214,19 @@ where
     #[allow(clippy::wrong_self_convention)]
     pub fn to_iter(
         mut self,
-    ) -> impl Iterator<Item = Result<StreamingValue<Value>, ValuesError<Ctx>>> {
+    ) -> impl Iterator<Item = Result<StreamingValue<Ctx::Value>, ValuesError<Ctx>>> {
         core::iter::from_fn(move || Iterator::next(&mut self))
     }
 }
 
 impl<Ctx, A> Iterator for JsonModemValuesClosed<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
-    type Item = Result<StreamingValue<Value>, ValuesError<Ctx>>;
+    type Item = Result<StreamingValue<Ctx::Value>, ValuesError<Ctx>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_value_ref().map(clone_streaming_value)
@@ -226,7 +235,8 @@ where
 
 impl<Ctx, A> LendingIterator for JsonModemValuesClosed<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -253,9 +263,10 @@ fn convert_error<Ctx: EventCtx>(err: BufferError<Ctx>) -> ValuesError<Ctx> {
 
 fn clone_streaming_value<Ctx>(
     result: Result<StreamingValue<&Ctx::Value>, ValuesError<Ctx>>,
-) -> Result<StreamingValue<Value>, ValuesError<Ctx>>
+) -> Result<StreamingValue<Ctx::Value>, ValuesError<Ctx>>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
+    Ctx::Value: Clone,
 {
     result.map(|borrowed| StreamingValue {
         index: borrowed.index,
@@ -266,7 +277,7 @@ where
 
 trait ValueSource<Ctx>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
 {
     fn next_event(&mut self) -> Option<Result<BorrowedBufferedEvent<'_, Ctx>, BufferError<Ctx>>>;
@@ -275,7 +286,7 @@ where
 
 impl<Ctx, A> ValueSource<Ctx> for JsonModemBuffersIter<'_, Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -290,7 +301,7 @@ where
 
 impl<Ctx, A> ValueSource<Ctx> for JsonModemBuffersClosed<Ctx, A>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
     A: RootedBufferAssembler<Ctx>,
 {
@@ -309,7 +320,7 @@ fn next_value_for_source<'a, Ctx, S>(
     next_index: &'a mut usize,
 ) -> Option<Result<StreamingValue<&'a Ctx::Value>, ValuesError<Ctx>>>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
     S: ValueSource<Ctx>,
 {
@@ -382,7 +393,7 @@ fn next_emit_kind<Ctx, S>(
     saw_partial: &mut bool,
 ) -> Option<Result<EmitKind, ValuesError<Ctx>>>
 where
-    Ctx: BuilderCtx<Value = Value> + EventCtx,
+    Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
     S: ValueSource<Ctx>,
 {

--- a/crates/jsonmodem/src/lib.rs
+++ b/crates/jsonmodem/src/lib.rs
@@ -22,6 +22,8 @@ mod buffer_options;
 mod context;
 mod event;
 mod jsonmodem_buffers;
+#[cfg(feature = "im")]
+mod jsonmodem_im;
 mod jsonmodem_values;
 pub mod lending_iterator;
 mod parser;
@@ -31,7 +33,9 @@ mod value_tree;
 
 #[doc(hidden)]
 pub use backend::raw::RawBufferAssembler;
-pub use backend::{RawContext, StdBackend};
+pub use backend::{
+    ImBackend, ImStringAssembler, ImValueAssembler, RawContext, StdBackend, im_value,
+};
 pub use buffer_options::BufferOptions;
 // Expose core parser types publicly for users building custom adapters, while
 // keeping the low-level `JsonModem` constructor out of the docs surface.
@@ -40,6 +44,11 @@ pub use event::ParseEvent;
 #[allow(unused_imports)]
 pub use event::test_util;
 pub use jsonmodem_buffers::{BufferedEvent, JsonModemBuffers};
+#[cfg(feature = "im")]
+pub use jsonmodem_im::{
+    JsonModemIm, JsonModemImClosed, JsonModemImClosedResultIter, JsonModemImIter,
+    JsonModemImResultIter,
+};
 pub use jsonmodem_values::{JsonModemValues, StreamingValue, ValuesOptions};
 #[doc(hidden)]
 pub use parser::JsonModem;

--- a/crates/jsonmodem/src/tests/property_multivalue.rs
+++ b/crates/jsonmodem/src/tests/property_multivalue.rs
@@ -10,6 +10,7 @@ use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 
 use crate::parser::{JsonModem, ParseEvent, ParserOptions};
 type DefaultStreamingParser = JsonModem<crate::backend::StdBackend>;
+type ImmutableStreamingParser = JsonModem<crate::backend::ImBackend>;
 
 // Minimal JSON Value for property tests
 #[derive(Clone, Debug, PartialEq)]
@@ -255,6 +256,13 @@ fn append_string_at_path(target: &mut Value, path: &[crate::PathItem], fragment:
     }
 }
 
+fn clone_path_to_vec<P>(path: &P) -> crate::Path
+where
+    for<'a> &'a P: IntoIterator<Item = &'a crate::PathItem>,
+{
+    path.into_iter().cloned().collect()
+}
+
 struct Assembler {
     out: Vec<Value>,
     cur: Value,
@@ -269,40 +277,54 @@ impl Assembler {
             building: false,
         }
     }
-    fn apply(&mut self, evt: ParseEvent<'_, crate::Path, crate::backend::StdBackend>) {
+    fn apply<Ctx>(&mut self, evt: ParseEvent<'_, Ctx::Path, Ctx>)
+    where
+        Ctx: crate::context::EventCtx,
+        for<'a> &'a Ctx::Path: IntoIterator<Item = &'a crate::PathItem>,
+        for<'a> Ctx::Str<'a>: AsRef<str>,
+        Ctx::Bool: Copy + Into<bool>,
+        for<'a> Ctx::Num<'a>: Copy + Into<f64>,
+    {
         match evt {
             ParseEvent::ArrayBegin { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Array(Vec::new()));
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Array(Vec::new()));
+                if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::ObjectBegin { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Object(BTreeMap::new()));
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Object(BTreeMap::new()));
+                if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::Null { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Null);
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Null);
+                if path_vec.is_empty() {
                     self.out.push(Value::Null);
                     self.cur = Value::Null;
                     self.building = false;
                 }
             }
             ParseEvent::Boolean { path, value } => {
-                insert_at_path(&mut self.cur, &path, Value::Boolean(value));
-                if path.is_empty() {
-                    self.out.push(Value::Boolean(value));
+                let path_vec = clone_path_to_vec(&path);
+                let bool_value: bool = value.into();
+                insert_at_path(&mut self.cur, &path_vec, Value::Boolean(bool_value));
+                if path_vec.is_empty() {
+                    self.out.push(Value::Boolean(bool_value));
                     self.cur = Value::Null;
                     self.building = false;
                 }
             }
             ParseEvent::Number { path, value } => {
-                insert_at_path(&mut self.cur, &path, Value::Number(value));
-                if path.is_empty() {
-                    self.out.push(Value::Number(value));
+                let path_vec = clone_path_to_vec(&path);
+                let num_value: f64 = value.into();
+                insert_at_path(&mut self.cur, &path_vec, Value::Number(num_value));
+                if path_vec.is_empty() {
+                    self.out.push(Value::Number(num_value));
                     self.cur = Value::Null;
                     self.building = false;
                 }
@@ -313,17 +335,19 @@ impl Assembler {
                 is_final,
                 ..
             } => {
-                append_string_at_path(&mut self.cur, &path, &fragment);
-                if is_final && path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                append_string_at_path(&mut self.cur, &path_vec, fragment.as_ref());
+                if is_final && path_vec.is_empty() {
                     self.out.push(self.cur.clone());
                     self.cur = Value::Null;
                     self.building = false;
-                } else if path.is_empty() {
+                } else if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::ArrayEnd { path } | ParseEvent::ObjectEnd { path } => {
-                if path.is_empty() && self.building {
+                let path_vec = clone_path_to_vec(&path);
+                if path_vec.is_empty() && self.building {
                     self.out.push(self.cur.clone());
                     self.cur = Value::Null;
                     self.building = false;
@@ -355,78 +379,97 @@ fn repro_multi_value_string_root() {
     assert_eq!(reconstructed, vec![Value::String("x".into())]);
 }
 
-/// Property: A stream consisting of multiple JSON roots must round-trip through
-/// the incremental parser regardless of input partitioning.
 #[test]
-fn prop_multi_value_roundtrip() {
-    #[expect(clippy::needless_pass_by_value)]
-    fn prop(values: Vec<Value>, splits: Vec<usize>) -> TestResult {
-        if values.is_empty() {
-            return TestResult::discard();
+fn repro_multi_value_string_root_im() {
+    let payload = "\"x\"";
+    let mut parser = ImmutableStreamingParser::new(
+        ParserOptions::default().with_allow_multiple_json_values(true),
+    );
+    let mut r = Assembler::new();
+    for e in parser.feed(payload).to_iter() {
+        r.apply(e.unwrap());
+    }
+    let reconstructed = r.finish();
+    assert_eq!(reconstructed, vec![Value::String("x".into())]);
+}
+
+fn prop_multi_value_roundtrip_backend<Ctx>(values: Vec<Value>, splits: &[usize]) -> TestResult
+where
+    Ctx: crate::context::EventCtx + crate::context::PathCtx + crate::context::BuilderCtx + Default,
+    for<'a> &'a Ctx::Path: IntoIterator<Item = &'a crate::PathItem>,
+    for<'a> Ctx::Str<'a>: AsRef<str>,
+    Ctx::Bool: Copy + Into<bool>,
+    for<'a> Ctx::Num<'a>: Copy + Into<f64>,
+{
+    if values.is_empty() {
+        return TestResult::discard();
+    }
+
+    let mut payload: String = values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" ");
+    payload.push(' ');
+
+    let mut parser =
+        JsonModem::<Ctx>::new(ParserOptions::default().with_allow_multiple_json_values(true));
+    let mut reb = Assembler::new();
+
+    let chars: Vec<char> = payload.chars().collect();
+    let mut idx = 0;
+    let mut remaining = chars.len();
+
+    for &s in splits {
+        if remaining == 0 {
+            break;
         }
-
-        // Join all roots separated by a single space (valid JSON whitespace).
-        let mut payload: String = values
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(" ");
-        payload.push(' '); // ensure delimiter to finalize last primitive
-
-        let mut parser = DefaultStreamingParser::new(
-            ParserOptions::default().with_allow_multiple_json_values(true),
-        );
-        let mut reb = Assembler::new();
-
-        // For debugging purposes:
-        let mut chunks = vec![];
-
-        // Feed payload in arbitrary partitions
-        let chars: Vec<char> = payload.chars().collect();
-        let mut idx = 0;
-        let mut remaining = chars.len();
-
-        for s in &splits {
-            if remaining == 0 {
-                break;
-            }
-            let size = 1 + (s % remaining);
-            let end = idx + size;
-            let chunk: String = chars[idx..end].iter().collect();
-            chunks.push(chunk.clone());
-            for ev in parser.feed(&chunk).to_iter() {
-                match ev {
-                    Ok(e) => reb.apply(e),
-                    Err(_) => return TestResult::failed(),
-                }
-            }
-            idx = end;
-            remaining -= size;
-        }
-        if remaining > 0 {
-            let chunk: String = chars[idx..].iter().collect();
-
-            chunks.push(chunk.clone());
-            for ev in parser.feed(&chunk).to_iter() {
-                match ev {
-                    Ok(e) => reb.apply(e),
-                    Err(_) => return TestResult::failed(),
-                }
-            }
-        }
-        for ev in parser.finish().to_iter() {
+        let size = 1 + (s % remaining);
+        let end = idx + size;
+        let chunk: String = chars[idx..end].iter().collect();
+        for ev in parser.feed(&chunk).to_iter() {
             match ev {
                 Ok(e) => reb.apply(e),
                 Err(_) => return TestResult::failed(),
             }
         }
+        idx = end;
+        remaining -= size;
+    }
+    if remaining > 0 {
+        let chunk: String = chars[idx..].iter().collect();
+        for ev in parser.feed(&chunk).to_iter() {
+            match ev {
+                Ok(e) => reb.apply(e),
+                Err(_) => return TestResult::failed(),
+            }
+        }
+    }
+    for ev in parser.finish().to_iter() {
+        match ev {
+            Ok(e) => reb.apply(e),
+            Err(_) => return TestResult::failed(),
+        }
+    }
 
-        let reconstructed = reb.finish();
-        let original: Vec<Value> = values.into_iter().collect();
+    let reconstructed = reb.finish();
+    let original: Vec<Value> = values.into_iter().collect();
 
-        let result = reconstructed == original;
+    TestResult::from_bool(reconstructed == original)
+}
 
-        TestResult::from_bool(result)
+/// Property: A stream consisting of multiple JSON roots must round-trip through
+/// the incremental parser regardless of input partitioning.
+#[test]
+fn prop_multi_value_roundtrip() {
+    #[expect(clippy::needless_pass_by_value)]
+    fn prop_std(values: Vec<Value>, splits: Vec<usize>) -> TestResult {
+        prop_multi_value_roundtrip_backend::<crate::backend::StdBackend>(values, &splits)
+    }
+
+    #[expect(clippy::needless_pass_by_value)]
+    fn prop_im(values: Vec<Value>, splits: Vec<usize>) -> TestResult {
+        prop_multi_value_roundtrip_backend::<crate::backend::ImBackend>(values, &splits)
     }
 
     let tests = if cfg!(miri) || std::env::var_os("JSONMODEM_TEST_FAST").is_some() {
@@ -439,7 +482,11 @@ fn prop_multi_value_roundtrip() {
 
     QuickCheck::new()
         .tests(tests)
-        .quickcheck(prop as fn(Vec<Value>, Vec<usize>) -> TestResult);
+        .quickcheck(prop_std as fn(Vec<Value>, Vec<usize>) -> TestResult);
+
+    QuickCheck::new()
+        .tests(tests)
+        .quickcheck(prop_im as fn(Vec<Value>, Vec<usize>) -> TestResult);
 }
 
 #[test]
@@ -447,6 +494,29 @@ fn multi_value_roundtrip_repro() {
     let chunks = ["{\"/ꑆ\u{fff2}\u{4a9d3}‼\"", ":\"\u{e1cac}\",\">]\":false}"];
 
     let mut parser = DefaultStreamingParser::new(
+        ParserOptions::default()
+            .with_allow_multiple_json_values(true)
+            .with_panic_on_error(true),
+    );
+    for chunk in &chunks {
+        for ev in parser.feed(chunk).to_iter() {
+            if let Err(err) = ev {
+                panic!("Error while parsing: {err}");
+            }
+        }
+    }
+    for ev in parser.finish().to_iter() {
+        if let Err(err) = ev {
+            panic!("Error while parsing: {err}");
+        }
+    }
+}
+
+#[test]
+fn multi_value_roundtrip_repro_im() {
+    let chunks = ["{\"/ꑆ\u{fff2}\u{4a9d3}‼\"", ":\"\u{e1cac}\",\">]\":false}"];
+
+    let mut parser = ImmutableStreamingParser::new(
         ParserOptions::default()
             .with_allow_multiple_json_values(true)
             .with_panic_on_error(true),

--- a/crates/jsonmodem/src/tests/property_partition.rs
+++ b/crates/jsonmodem/src/tests/property_partition.rs
@@ -8,7 +8,6 @@ use alloc::{
 use quickcheck::{Arbitrary, Gen, QuickCheck};
 
 use crate::parser::{JsonModem, ParseEvent, ParserOptions};
-type DefaultStreamingParser = JsonModem<crate::backend::StdBackend>;
 
 #[derive(Clone, Debug, PartialEq)]
 enum Value {
@@ -252,6 +251,13 @@ fn append_string_at_path(target: &mut Value, path: &[crate::PathItem], fragment:
     }
 }
 
+fn clone_path_to_vec<P>(path: &P) -> crate::Path
+where
+    for<'a> &'a P: IntoIterator<Item = &'a crate::PathItem>,
+{
+    path.into_iter().cloned().collect()
+}
+
 struct Assembler {
     out: Vec<Value>,
     cur: Value,
@@ -265,40 +271,54 @@ impl Assembler {
             building: false,
         }
     }
-    fn apply(&mut self, evt: ParseEvent<'_, crate::Path, crate::backend::StdBackend>) {
+    fn apply<Ctx>(&mut self, evt: ParseEvent<'_, Ctx::Path, Ctx>)
+    where
+        Ctx: crate::context::EventCtx,
+        for<'a> &'a Ctx::Path: IntoIterator<Item = &'a crate::PathItem>,
+        for<'a> Ctx::Str<'a>: AsRef<str>,
+        Ctx::Bool: Copy + Into<bool>,
+        for<'a> Ctx::Num<'a>: Copy + Into<f64>,
+    {
         match evt {
             ParseEvent::ArrayBegin { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Array(Vec::new()));
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Array(Vec::new()));
+                if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::ObjectBegin { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Object(BTreeMap::new()));
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Object(BTreeMap::new()));
+                if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::Null { path } => {
-                insert_at_path(&mut self.cur, &path, Value::Null);
-                if path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                insert_at_path(&mut self.cur, &path_vec, Value::Null);
+                if path_vec.is_empty() {
                     self.out.push(Value::Null);
                     self.cur = Value::Null;
                     self.building = false;
                 }
             }
             ParseEvent::Boolean { path, value } => {
-                insert_at_path(&mut self.cur, &path, Value::Boolean(value));
-                if path.is_empty() {
-                    self.out.push(Value::Boolean(value));
+                let path_vec = clone_path_to_vec(&path);
+                let bool_value: bool = value.into();
+                insert_at_path(&mut self.cur, &path_vec, Value::Boolean(bool_value));
+                if path_vec.is_empty() {
+                    self.out.push(Value::Boolean(bool_value));
                     self.cur = Value::Null;
                     self.building = false;
                 }
             }
             ParseEvent::Number { path, value } => {
-                insert_at_path(&mut self.cur, &path, Value::Number(value));
-                if path.is_empty() {
-                    self.out.push(Value::Number(value));
+                let path_vec = clone_path_to_vec(&path);
+                let num_value: f64 = value.into();
+                insert_at_path(&mut self.cur, &path_vec, Value::Number(num_value));
+                if path_vec.is_empty() {
+                    self.out.push(Value::Number(num_value));
                     self.cur = Value::Null;
                     self.building = false;
                 }
@@ -309,17 +329,19 @@ impl Assembler {
                 is_final,
                 ..
             } => {
-                append_string_at_path(&mut self.cur, &path, &fragment);
-                if is_final && path.is_empty() {
+                let path_vec = clone_path_to_vec(&path);
+                append_string_at_path(&mut self.cur, &path_vec, fragment.as_ref());
+                if is_final && path_vec.is_empty() {
                     self.out.push(self.cur.clone());
                     self.cur = Value::Null;
                     self.building = false;
-                } else if path.is_empty() {
+                } else if path_vec.is_empty() {
                     self.building = true;
                 }
             }
             ParseEvent::ArrayEnd { path } | ParseEvent::ObjectEnd { path } => {
-                if path.is_empty() && self.building {
+                let path_vec = clone_path_to_vec(&path);
+                if path_vec.is_empty() && self.building {
                     self.out.push(self.cur.clone());
                     self.cur = Value::Null;
                     self.building = false;
@@ -337,58 +359,68 @@ impl Assembler {
 
 /// Property: Feeding a JSON document in arbitrary chunk sizes must yield the
 /// exact same `Value` when reconstructed from the emitted `ParseEvent`s.
+fn prop_partition_roundtrip_backend<Ctx>(value: &Value, splits: &[usize]) -> bool
+where
+    Ctx: crate::context::EventCtx + crate::context::PathCtx + crate::context::BuilderCtx + Default,
+    for<'a> &'a Ctx::Path: IntoIterator<Item = &'a crate::PathItem>,
+    for<'a> Ctx::Str<'a>: AsRef<str>,
+    Ctx::Bool: Copy + Into<bool>,
+    for<'a> Ctx::Num<'a>: Copy + Into<f64>,
+{
+    let src = {
+        let mut s = value.to_string();
+        s.push(' ');
+        s
+    };
+    if src.is_empty() {
+        return true;
+    }
+
+    let mut parser =
+        JsonModem::<Ctx>::new(ParserOptions::default().with_allow_multiple_json_values(true));
+    let mut reb = Assembler::new();
+    let chars: Vec<char> = src.chars().collect();
+    let mut idx = 0;
+    let mut remaining = chars.len();
+
+    for &s in splits {
+        if remaining == 0 {
+            break;
+        }
+        let size = 1 + (s % remaining);
+        let end = idx + size;
+        let chunk: String = chars[idx..end].iter().collect();
+        for e in parser.feed(&chunk).to_iter().flatten() {
+            reb.apply(e);
+        }
+        idx = end;
+        remaining -= size;
+    }
+    if remaining > 0 {
+        let chunk: String = chars[idx..].iter().collect();
+        for e in parser.feed(&chunk).to_iter().flatten() {
+            reb.apply(e);
+        }
+    }
+
+    for e in parser.finish().to_iter().flatten() {
+        reb.apply(e);
+    }
+
+    let reconstructed = reb.finish();
+    reconstructed.len() == 1 && reconstructed[0] == *value
+}
+
 #[test]
 fn prop_partition_roundtrip() {
     #[expect(clippy::needless_pass_by_value)]
     fn prop(value: Value, splits: Vec<usize>) -> bool {
-        let src = {
-            let mut s = value.to_string();
-            s.push(' '); // ensure delimiter for primitives
-            s
-        };
-        if src.is_empty() {
-            return true;
-        }
+        prop_partition_roundtrip_backend::<crate::backend::StdBackend>(&value, &splits)
+    }
 
-        // Stream parser DefaultStreamingParser so that structural container events are
-        // emitted.
-        let mut parser = DefaultStreamingParser::new(
-            ParserOptions::default().with_allow_multiple_json_values(true),
-        );
-        let mut reb = Assembler::new();
-        // Feed the JSON text in arbitrarily sized UTF-8-safe chunks (derived from
-        // `splits`).
-        let chars: Vec<char> = src.chars().collect();
-        let mut idx = 0;
-        let mut remaining = chars.len();
-
-        for s in splits {
-            if remaining == 0 {
-                break;
-            }
-            let size = 1 + (s % remaining);
-            let end = idx + size;
-            let chunk: String = chars[idx..end].iter().collect();
-            for e in parser.feed(&chunk).to_iter().flatten() {
-                reb.apply(e);
-            }
-            idx = end;
-            remaining -= size;
-        }
-        if remaining > 0 {
-            let chunk: String = chars[idx..].iter().collect();
-            for e in parser.feed(&chunk).to_iter().flatten() {
-                reb.apply(e);
-            }
-        }
-
-        // Flush any pending events.
-        for e in parser.finish().to_iter().flatten() {
-            reb.apply(e);
-        }
-
-        let reconstructed = reb.finish();
-        reconstructed.len() == 1 && reconstructed[0] == value
+    #[expect(clippy::needless_pass_by_value)]
+    fn prop_im(value: Value, splits: Vec<usize>) -> bool {
+        prop_partition_roundtrip_backend::<crate::backend::ImBackend>(&value, &splits)
     }
 
     let tests = if cfg!(miri) || std::env::var_os("JSONMODEM_TEST_FAST").is_some() {
@@ -402,4 +434,8 @@ fn prop_partition_roundtrip() {
     QuickCheck::new()
         .tests(tests)
         .quickcheck(prop as fn(Value, Vec<usize>) -> bool);
+
+    QuickCheck::new()
+        .tests(tests)
+        .quickcheck(prop_im as fn(Value, Vec<usize>) -> bool);
 }

--- a/crates/jsonmodem/tests/im_adapter.rs
+++ b/crates/jsonmodem/tests/im_adapter.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "im")]
+#![allow(missing_docs)]
+//! Sanity test for the feature-gated `JsonModemIm` adapter.
+
+use jsonmodem::{JsonModemIm, ParserOptions, ValuesOptions};
+use serde_json::Value as SerdeValue;
+
+#[test]
+fn jsonmodem_im_snapshots_are_stable() {
+    let mut adapter = JsonModemIm::with_options(
+        ParserOptions::default(),
+        ValuesOptions::default().with_partial(true),
+    );
+
+    let mut collected = Vec::new();
+
+    for chunk in &["{\"title\":\"he", "llo\",\"nums\":[1", ",2,3]}"] {
+        for snapshot in adapter.feed(chunk) {
+            collected.push(snapshot);
+        }
+    }
+
+    for snapshot in adapter.finish() {
+        collected.push(snapshot);
+    }
+
+    let final_snapshot = collected
+        .into_iter()
+        .rev()
+        .find(|snapshot| snapshot.is_final)
+        .expect("expected a final snapshot from JsonModemIm");
+
+    assert_eq!(
+        serde_json::from_str::<SerdeValue>(&final_snapshot.value.to_string()).unwrap(),
+        serde_json::json!({"title": "hello", "nums": [1, 2, 3]})
+    );
+}

--- a/crates/jsonmodem/tests/im_spikes.rs
+++ b/crates/jsonmodem/tests/im_spikes.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+#![allow(missing_docs)]
+//! Spikes exercising `EcoString` and `rpds` persistent containers to understand
+//! mutation behaviour.
+
+use ecow::EcoString;
+use rpds::{RedBlackTreeMapSync, VectorSync};
+
+#[test]
+fn eco_string_clone_is_copy_on_write() {
+    let mut original = EcoString::from("hello");
+    let mut cloned = original.clone();
+
+    cloned.push_str(" world");
+    assert_eq!(
+        original.as_str(),
+        "hello",
+        "mutating the clone must not alter the original"
+    );
+    assert_eq!(cloned.as_str(), "hello world");
+
+    original.push('!');
+    assert_eq!(
+        original.as_str(),
+        "hello!",
+        "original remains mutable and independent"
+    );
+    assert_eq!(cloned.as_str(), "hello world");
+}
+
+#[test]
+fn eco_string_inline_capacity_handles_fragment_appends() {
+    let mut s = EcoString::from("");
+    for _ in 0..4 {
+        s.push_str("abcd");
+    }
+    assert_eq!(s.len(), 16, "appends should extend the EcoString length");
+    assert_eq!(s.as_str(), "abcdabcdabcdabcd");
+}
+
+#[test]
+fn vector_sync_structural_sharing() {
+    let base = VectorSync::new_sync();
+    let extended = base.push_back(1).push_back(2);
+
+    assert_eq!(extended.len(), 2);
+    assert_eq!(
+        base.len(),
+        0,
+        "push_back returns a new vector without mutating the original"
+    );
+
+    let mut mutable = extended.clone();
+    mutable.push_back_mut(3);
+    assert_eq!(mutable.len(), 3);
+    assert_eq!(mutable.iter().collect::<Vec<_>>(), vec![&1, &2, &3]);
+
+    assert_eq!(
+        extended.iter().collect::<Vec<_>>(),
+        vec![&1, &2],
+        "mutating the clone must not affect the original vector"
+    );
+}
+
+#[test]
+fn vector_sync_set_mut_updates_in_place() {
+    let mut values = VectorSync::new_sync();
+    values.push_back_mut(10);
+    values.push_back_mut(20);
+
+    {
+        let slot = values.get_mut(1).expect("second element present");
+        *slot = 99;
+    }
+
+    assert_eq!(values.iter().collect::<Vec<_>>(), vec![&10, &99]);
+}
+
+#[test]
+fn red_black_tree_map_sync_insert_mut_preserves_existing_entries() {
+    let mut map = RedBlackTreeMapSync::new_sync();
+    map.insert_mut("a", 1);
+    map.insert_mut("b", 2);
+
+    {
+        let entry = map.get_mut("a").expect("entry exists");
+        *entry = 42;
+    }
+
+    assert_eq!(map.get("a"), Some(&42));
+    assert_eq!(map.get("b"), Some(&2));
+
+    let snapshot_keys: Vec<_> = map.keys().copied().collect();
+    assert_eq!(snapshot_keys, vec!["a", "b"]);
+}

--- a/crates/jsonmodem/tests/jsonmodem_values/tests.rs
+++ b/crates/jsonmodem/tests/jsonmodem_values/tests.rs
@@ -2,7 +2,10 @@
 use std::string::ToString;
 
 use insta::assert_snapshot;
-use jsonmodem::{JsonModemValues, ParserOptions, StreamingValue, Value, ValuesOptions};
+use jsonmodem::{
+    BufferOptions, ImValueAssembler, JsonModemValues, ParserOptions, StreamingValue, Value,
+    ValuesOptions,
+};
 use quickcheck::QuickCheck;
 use serde_json::{self, Value as SerdeValue};
 
@@ -33,6 +36,104 @@ fn collect_streaming_values(chunks: &[&str], options: ValuesOptions) -> Vec<Stre
     }
     out.extend(modem.finish().map(|res| res.expect("values finish error")));
     out
+}
+
+fn collect_im_streaming_values(
+    chunks: &[&str],
+    options: ValuesOptions,
+) -> Vec<StreamingValue<String>> {
+    let assembler = ImValueAssembler::new(BufferOptions::default());
+    let mut modem =
+        JsonModemValues::with_buffer_builder(ParserOptions::default(), options, assembler);
+    let mut out = Vec::new();
+    for chunk in chunks {
+        for value in modem.feed(chunk) {
+            let value = value.expect("im values iterator error");
+            out.push(StreamingValue {
+                index: value.index,
+                value: value.value.to_string(),
+                is_final: value.is_final,
+            });
+        }
+    }
+    for value in modem.finish() {
+        let value = value.expect("im values finish error");
+        out.push(StreamingValue {
+            index: value.index,
+            value: value.value.to_string(),
+            is_final: value.is_final,
+        });
+    }
+    out
+}
+
+#[test]
+fn im_backend_basic_roundtrip() {
+    let assembler = ImValueAssembler::new(BufferOptions::default());
+    let mut values = JsonModemValues::with_buffer_builder(
+        ParserOptions::default(),
+        ValuesOptions::default(),
+        assembler,
+    );
+
+    let mut finals = Vec::new();
+    for value in values.feed("[1,2,3]") {
+        let value = value.expect("iterator error");
+        if value.is_final {
+            finals.push(value.value.to_string());
+        }
+    }
+
+    for value in values.finish() {
+        let value = value.expect("finish error");
+        if value.is_final {
+            finals.push(value.value.to_string());
+        }
+    }
+
+    assert_eq!(finals, ["[1,2,3]".to_string()]);
+}
+
+#[test]
+fn im_backend_handles_nested_chunks() {
+    let assembler = ImValueAssembler::new(BufferOptions::default());
+    let mut values = JsonModemValues::with_buffer_builder(
+        ParserOptions::default(),
+        ValuesOptions::default(),
+        assembler,
+    );
+
+    let chunks = [
+        "{\"outer\":{\"inner\":\"va",
+        "lu\",\"list\":[1,",
+        "2,3]},\"flag\":true}",
+    ];
+
+    let mut finals = Vec::new();
+    for chunk in &chunks {
+        for value in values.feed(chunk) {
+            let value = value.expect("iterator error");
+            if value.is_final {
+                finals.push(value.value.to_string());
+            }
+        }
+    }
+
+    for value in values.finish() {
+        let value = value.expect("finish error");
+        if value.is_final {
+            finals.push(value.value.to_string());
+        }
+    }
+
+    let actual = finals
+        .pop()
+        .expect("expected a final value from immutable backend");
+    let parsed: SerdeValue = serde_json::from_str(&actual).unwrap();
+    let expected: SerdeValue =
+        serde_json::from_str("{\"outer\":{\"inner\":\"valu\",\"list\":[1,2,3]},\"flag\":true}")
+            .unwrap();
+    assert_eq!(parsed, expected);
 }
 
 fn render_streaming_values(chunks: &[&str], options: ValuesOptions) -> String {
@@ -156,9 +257,46 @@ fn values_array_matches_serde(digits: Vec<u8>, chunk_size: u8) -> bool {
     final_value == expected
 }
 
+fn im_values_array_matches_serde(digits: Vec<u8>, chunk_size: u8) -> bool {
+    let values: Vec<i16> = digits
+        .into_iter()
+        .map(|value| i16::from(value % 10))
+        .collect();
+    let joined = values
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let json = format!("[{joined}]");
+    let chunk_size = usize::from(chunk_size.max(1));
+    let chunked = chunk_input(&json, chunk_size);
+    let borrowed = chunked.iter().map(String::as_str).collect::<Vec<_>>();
+
+    let outputs = collect_im_streaming_values(&borrowed, ValuesOptions::default());
+
+    if outputs.is_empty() {
+        return true;
+    }
+
+    let final_value = match outputs.iter().rev().find(|value| value.is_final) {
+        Some(value) => value.value.clone(),
+        None => return false,
+    };
+
+    let expected = serde_json::to_string(&SerdeValue::from(values)).unwrap();
+    final_value == expected
+}
+
 #[test]
 fn prop_values_array_roundtrip() {
     QuickCheck::new()
         .tests(50)
         .quickcheck(values_array_matches_serde as fn(Vec<u8>, u8) -> bool);
+}
+
+#[test]
+fn prop_im_values_array_roundtrip() {
+    QuickCheck::new()
+        .tests(50)
+        .quickcheck(im_values_array_matches_serde as fn(Vec<u8>, u8) -> bool);
 }

--- a/plans/im/im-execplan.md
+++ b/plans/im/im-execplan.md
@@ -1,0 +1,207 @@
+# Deliver an Immutable JsonModem Backend
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `PLANS.md` in the repository root for the governing standards. This document is authored and maintained in accordance with those requirements.
+
+## Purpose / Big Picture
+
+JsonModem currently exposes only `StdBackend`, which materialises values using `String`, `Vec`, and `BTreeMap`. After completing this plan, contributors will be able to construct immutable JSON trees that reuse structure instead of cloning, by instantiating `JsonModem`, `JsonModemBuffers`, or `JsonModemValues` with a new `ImBackend`. The API surface will match the snippet in `docs/im/prompt.md`, and users can observe success by feeding chunked JSON into the immutable adapters and verifying the resulting values share structure, serialise correctly, and pass the existing adapters’ tests. The immutable backend will compile everywhere the crate runs today and will be exercised by benches and tests alongside the standard backend. Along the way, we will prototype a `JsonModemIm` interface that proves immutable roots can be exposed through ordinary iterators, reducing reliance on lending lifetimes for callers that prefer a simpler ownership model.
+
+## Progress
+
+- [x] (2025-02-14 00:00Z) Authored initial ExecPlan describing how to recreate the immutable backend from HEAD~1..HEAD.
+- [x] (2025-02-14 02:15Z) Ran EcoString and rpds spikes (`cargo test --test im_spikes`) documenting copy-on-write semantics and persistent container mutations.
+- [x] (2025-02-14 02:35Z) Prototyped a `JsonModemIm` adapter with stored immutable snapshots (`cargo test --features im --test im_adapter`).
+- [x] (2025-02-14 02:45Z) Verified dependency scaffolding, upstream mirrors (`tmp/upstream/{ecow,rpds}`), and updated `docs/im/im-execplan.md` with spike findings.
+- [x] (2025-02-14 02:50Z) Confirmed immutable backend modules (`value`, `value_zipper`, `value_applicator`, `mod`) satisfy trait integrations and doc coverage.
+- [x] (2025-02-14 03:00Z) Exercised adapters/tests and Criterion benches (`cargo test --test jsonmodem_values`, `JSONMODEM_BENCH_FAST=1 cargo bench --bench streaming_json_medium`).
+- [x] (2025-02-14 03:10Z) Finalised documentation and validation (`.agent/check.sh` clean, spec updated with spike/prototype findings).
+- [x] (2025-02-14 03:20Z) Productised `JsonModemIm` behind the `im` feature (opt-in for consumers, enabled in `.agent/check.sh`).
+
+## Surprises & Discoveries
+
+- `ecow::EcoString` clones may immediately allocate separate inline buffers; pointer equality is not a reliable signal of sharing, but copy-on-write semantics still ensure independent mutation once we call `push_str`. Demonstrated in `crates/jsonmodem/tests/im_spikes.rs:9`.
+- `rpds::VectorSync::push_back_mut` mutates a clone in place without affecting earlier clones, confirming we can maintain persistent prefixes when appending array items. Verified by `vector_sync_structural_sharing` in `crates/jsonmodem/tests/im_spikes.rs:32`.
+- Storing `ImBackend` snapshots in a Vec enables a plain iterator over `&Value` without lending lifetimes; structural sharing keeps clones cheap and serde equality verifies stability (`crates/jsonmodem/tests/im_adapter.rs:38`).
+- Criterion benches show the IM variants working end-to-end, albeit with expected overhead versus the std backend (e.g., `streaming_json_medium/jsonmodem_values_im` ≈ 160 µs vs. `jsonmodem_values` ≈ 72 µs with `JSONMODEM_BENCH_FAST=1`).
+
+## Decision Log
+
+- (2025-02-14) Exposed the `im_value` module at the crate root (`lib.rs`) so downstream prototypes and documentation can reference the immutable `Value` type directly without relying on private modules.
+- (2025-02-14) Introduced the `im` Cargo feature, enabling `JsonModemIm` for local checks while keeping the crate’s default feature set empty for downstream consumers.
+
+## Outcomes & Retrospective
+
+- Immutable backend work is validated by green `.agent/check.sh`, targeted spikes, and benches comparing Std/IM paths. The prototype `JsonModemIm` demonstrates a viable direction for non-lending iteration, and documentation now captures empirical findings and open performance gaps.
+
+## Context and Orientation
+
+The repository hosts the `jsonmodem` crate in `crates/jsonmodem/`. Streaming adapters live under `crates/jsonmodem/src/`, with the standard backend in `backend/std/`. The new immutable backend will reside at `crates/jsonmodem/src/backend/im/`, parallel to the standard backend, so agents must mirror the existing structure when adding modules.
+
+JsonModem pipelines parse events through contexts (`PathCtx`, `EventCtx`, `BuilderCtx`, etc.). `JsonModemBuffers` coalesces fragments, and `JsonModemValues` builds composite values by delegating to a `RootedBufferAssembler`. The immutable backend must implement these contexts and assemblers so that existing adapters continue to function unchanged from the caller’s perspective. Persistent data structures will come from two crates:
+
+* `ecow::EcoString` provides a clone-on-write string with inline small-string storage. It is Send + Sync and allows zero-copy cloning, which is essential for string fragments observed multiple times.
+* `rpds::VectorSync<T>` and `rpds::RedBlackTreeMapSync<K, V>` implement persistent (functional) vector and map types that provide structural sharing across clones and mutations. They allow pushing or updating elements without copying the entire collection.
+
+The plan must also capture number handling. We will begin with `f64` to match existing behaviour, but the design must make it explicit how contributors could later swap to a more expressive number type under a feature flag. String decode modes (`StrictUnicode` versus `ReplaceInvalid`) require explicit surface APIs so callers can choose whether to lossy-convert invalid UTF-8 sequences.
+
+## Plan of Work
+
+Start with hands-on spikes. Build a scratch test module that exercises `ecow::EcoString` mutations, clone-on-write semantics, and interactions with reference types so we can prove that appending fragments or cloning values does not invalidate previously returned references. Create a companion spike that uses `rpds::VectorSync` and `rpds::RedBlackTreeMapSync` to simulate zipper operations: push array frames, insert object keys, mutate existing entries, and observe how `*_mut` APIs behave. These experiments should include assertions that verify sharing (for example, comparing pointer addresses or lengths before and after `push_back_mut`) and should be summarised in `Surprises & Discoveries` with exact file locations. Treat the spikes as executable documentation: they can live under `crates/jsonmodem/tests/` or an `experiments/` directory guarded by `#[cfg(test)]`.
+
+With the behaviour understood, expand the spike into a prototype adapter. Implement a lightweight `JsonModemIm` proof-of-concept—either as a stand-alone module or an integration test—that feeds synthetic parse events into an immutable value, retains the root, and exposes a standard iterator returning `&Value`. Use a fake or simplified backend if necessary to sidestep parser complexity. The goal is to confirm that persistent data structures allow us to return references without lending lifetimes, and to reveal any borrow-checker constraints before we touch production code. Record the outcome in the plan: either document the path to a production-ready adapter or note why the prototype fails and what blockers remain.
+
+Promote the validated design into a feature-gated production API. Create a `jsonmodem_im` module that is compiled when the `im` Cargo feature is enabled, implement a snapshotting `JsonModemIm` type with ergonomic iterators, and expose it from `lib.rs`. Update `.agent/check.sh` to pass `--features im` so local runs exercise the adapter, while keeping the crate’s default feature set empty for downstream consumers. Refresh documentation and tests to reference the new API and explain how to enable it.
+
+After the exploratory work, prepare the workspace. Add `ecow` and `rpds` to `crates/jsonmodem/Cargo.toml`, regenerate `Cargo.lock`, ignore `tmp/upstream/`, and pull relevant upstream documentation into `tmp/upstream/ecow/` and `tmp/upstream/rpds/` so offline contributors can inspect APIs. Capture the dependency rationale, spike findings, and safety implications in `docs/im/im-execplan.md`, including a layperson explanation of zippers (stack-backed cursors that let us modify a tree in place) and copy-on-write semantics.
+
+Next, scaffold the immutable backend modules. Mirror `backend/std/` by adding `value.rs` for the immutable `Value` enum and type aliases, `value_zipper.rs` for the persistent stack frames, and `value_applicator.rs` for event application. Implement `mod.rs` to expose `ImBackend`, `ImStringAssembler`, and `ImValueAssembler`, and satisfy the `PathCtx`, `EventCtx`, `OwnedEventCtx`, and `BuilderCtx` traits. Lean on insights from the spikes to document how `*_mut` conversions operate and why they are safe. Make sure each abstraction is defined in plain language so a newcomer knows what problem it solves.
+
+Once the backend compiles, integrate it with the public adapters. Allow callers to instantiate `JsonModem::<ImBackend>`, construct `JsonModemBuffers::with_builder` using an `ImValueAssembler`, and configure `JsonModemValues::with_buffer_builder`. Extend (or refactor) the prototype `JsonModemIm` into either production code or a documented experiment demonstrating the feasibility of non-lending iteration. Update benchmark helpers in `crates/jsonmodem/benches/streaming_json_common.rs` and related benches to add IM variants, maintaining symmetry with the standard backend. Expand unit tests in `crates/jsonmodem/tests/jsonmodem_values/tests.rs` to cover chunked feeds, partial snapshots, serde_json comparisons, and any behaviours surfaced by the spikes. Confirm the fuzz crate still compiles; adjust features or tests if the new backend affects build flags.
+
+Throughout the implementation, run `.agent/check.sh` after each major milestone to maintain a green workspace. When a test or lint fails, document the cause and fix in `Surprises & Discoveries` with a pointer to the resolving commit or file. After integrating adapters and tests, run the Criterion benches with `JSONMODEM_BENCH_FAST=1` to ensure IM variants execute without panics and to capture preliminary performance numbers.
+
+Finally, update documentation and reflect the experimental learnings. `docs/im/im-execplan.md` must summarise the architecture, number-handling decisions, decode modes, and Send + Sync guarantees, calling out how the spike results informed the design. Add module-level comments that clarify non-obvious logic (for example, why we rebuild EcoString fragments in a certain order). Once acceptance criteria are met, populate `Outcomes & Retrospective` with benchmarks, test evidence, and a discussion of whether the `JsonModemIm` adapter will proceed to production or remain an experiment.
+
+## Concrete Steps
+
+    # 1. Run EcoString and rpds spikes.
+    #    - Add crates/jsonmodem/tests/im_spikes.rs (cfg(test)) with focused tests that mutate EcoString, clone it, and confirm fragments remain valid.
+    #    - Write companion tests for rpds::VectorSync/RedBlackTreeMapSync demonstrating push_back_mut, set_mut, insert_mut, and structural sharing.
+    #    - Record behavioural notes in Surprises & Discoveries with file and line references.
+
+    # 2. Prototype a JsonModemIm adapter.
+    #    - Build crates/jsonmodem/tests/im_adapter.rs (feature-gated) to simulate feeding events into an immutable Value and expose a standard iterator returning &Value.
+    #    - Validate iterator lifetimes by holding references across multiple feed calls; add assertions covering mutation and observation.
+    #    - Summarise outcomes (viable path or blockers) in Surprises & Discoveries and log decisions if the design direction changes.
+
+    # 3. Add dependencies and upstream references.
+    #    - Edit crates/jsonmodem/Cargo.toml to include ecow and rpds.
+    #    - Update Cargo.lock via cargo fetch or build.
+    #    - Append tmp/upstream/ to .gitignore.
+    #    - Populate tmp/upstream/ecow/ and tmp/upstream/rpds/ with READMEs or checked-out sources for offline inspection.
+    #    - Draft docs/im/im-execplan.md with dependency rationale, spike findings, number handling, and safety notes.
+
+    # 4. Implement backend modules under crates/jsonmodem/src/backend/im/.
+    #    - value.rs: define Str, Array, Map aliases and the Value enum with Display/Debug helpers.
+    #    - value_zipper.rs: implement stack frames for arrays and objects using rpds persistent containers; explain push/pop semantics via comments.
+    #    - value_applicator.rs: translate ParseEvent streams into zipper operations, handling string fragments, numbers, booleans, nulls, arrays, and objects while leveraging EcoString behaviour validated in spikes.
+    #    - mod.rs: expose ImBackend, ImStringAssembler, and ImValueAssembler; implement PathCtx/EventCtx/OwnedEventCtx/BuilderCtx; surface decode modes.
+
+    # 5. Integrate adapters and public exports.
+    #    - Update crates/jsonmodem/src/backend/mod.rs and crates/jsonmodem/src/lib.rs to re-export new types.
+    #    - Ensure JsonModemBuffers and JsonModemValues accept ImValueAssembler without API changes; adjust generics only if required.
+    #    - Keep JsonModemValues-based smoke tests green while introducing additional adapters.
+
+    # 6. Expose the `im` feature and JsonModemIm API.
+    #    - Implement jsonmodem_im.rs with a feature-gated JsonModemIm type returning stable snapshot iterators.
+    #    - Re-export JsonModemIm (and helper iterators) when `im` is enabled; document the feature flag.
+    #    - Update .agent/check.sh to pass `--features im` so local workflows exercise the adapter, while keeping the crate’s default feature set empty.
+    #    - Replace the prototype test with coverage that targets the public feature-gated API.
+
+    # 7. Expand benches and tests.
+    #    - Modify crates/jsonmodem/benches/streaming_json_common.rs and related bench files to include IM variants (events, buffers, values).
+    #    - Extend crates/jsonmodem/tests/jsonmodem_values/tests.rs with immutable backend scenarios: basic roundtrip, nested chunked feeds, partial snapshots, serde_json comparisons, quickcheck hooks as needed.
+    #    - Reuse the property suites in crates/jsonmodem/src/tests/property_multivalue.rs and property_partition.rs so QuickCheck validates Std and IM backends with the same arbitrary data generators.
+    #    - Confirm fuzz crate builds; add compile-time checks if necessary.
+
+    # 8. Validation and documentation.
+    #    - Run .agent/check.sh until clean; resolve fmt, clippy, test, or bench issues.
+    #    - Execute JSONMODEM_BENCH_FAST=1 cargo bench --bench streaming_json_medium to confirm benches run with IM helpers (optional but recommended; record observations).
+    #    - Finalise docs/im/im-execplan.md with findings, safety guarantees, number/string decisions, and future work notes.
+    #    - Update this ExecPlan’s Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective.
+
+## Validation and Acceptance
+
+Success requires the following observable behaviours:
+
+- Running `.agent/check.sh` completes without failures, demonstrating that formatting, clippy, tests, and fuzz crate compilation succeed with the immutable backend present.
+- A user can execute the code snippet from `docs/im/prompt.md` (instantiating `JsonModem`, `JsonModemBuffers`, and `JsonModemValues` with `ImBackend`) in a smoke test and parse chunked JSON, yielding correctly formatted final values.
+- Criterion benches under `crates/jsonmodem/benches/` compile and report both Std and IM variants without panicking when run with `JSONMODEM_BENCH_FAST=1`.
+- Unit tests and spike suites (in `im_spikes.rs` and related prototypes) pass, demonstrating EcoString/rpds behaviour and validating the non-lending iterator experiment.
+- The experimental `JsonModemIm` prototype either lands as production code with passing tests or is documented in the Decision Log with clear blockers and follow-up actions.
+- `docs/im/im-execplan.md` exists and clearly documents design decisions, safety considerations, and future number/string extensibility, referencing insights from the spikes.
+
+## Idempotence and Recovery
+
+Adding dependencies to `Cargo.toml` is idempotent; rerunning `cargo fetch` or `.agent/check.sh` after edits is safe. Creating `tmp/upstream/*` directories can be repeated; if directories already exist, ensure content remains current or remove them before regenerating. Backend module implementations should be version-controlled; if an experiment fails, revert the affected files using `git checkout -- <paths>` to restore the last known-good state. Running benches with `JSONMODEM_BENCH_FAST=1` is non-destructive and can be repeated to confirm performance.
+
+## Artifacts and Notes
+
+Captured outputs:
+
+    ./.agent/check.sh
+        ✅ All stages succeeded (rustfmt, build, tests, clippy, docs); Miri skipped per environment flag.
+
+    JSONMODEM_BENCH_FAST=1 cargo bench --bench streaming_json_medium
+        streaming_json_medium/jsonmodem_values/1000      ~71.8 µs
+        streaming_json_medium/jsonmodem_values_im/1000   ~160.9 µs
+        streaming_json_medium/jsonmodem_buffers/5000     ~127 µs
+        streaming_json_medium/jsonmodem_buffers_im/5000  ~349 µs
+
+    cargo test --features im
+        ✅ Validates that the feature-gated JsonModemIm adapter and its snapshots behave as expected.
+
+These runs confirm the IM backend integrates with existing benches and highlight the current performance delta relative to the std backend.
+
+## Interfaces and Dependencies
+
+Implement or modify the following interfaces:
+
+    crates/jsonmodem/src/backend/im/value.rs
+        pub type Str = ecow::EcoString;
+        pub type Array = rpds::VectorSync<Value>;
+        pub type Map = rpds::RedBlackTreeMapSync<Str, Value>;
+        pub enum Value { Null, Boolean(bool), Number(f64), String(Str), Array(Array), Object(Map) }
+        Provide Display implementations for Value and helpers for constructing arrays/objects.
+
+    crates/jsonmodem/src/backend/im/value_zipper.rs
+        Define structs representing the current construction stack (arrays and objects).
+        Implement push/pop/set operations using rpds persistent containers with minimal cloning.
+
+    crates/jsonmodem/src/backend/im/value_applicator.rs
+        Expose ValueApplicator with methods:
+            pub fn new(options: BufferOptions) -> Self;
+            pub fn on_event(&mut self, event: ParseEvent<...>) -> Result<AppliedRef<'_>, ParseFloatError>;
+            pub fn read_root(&self) -> &Value;
+            pub fn take_root(&mut self) -> Value;
+        Ensure string fragments append correctly using EcoString.
+
+    crates/jsonmodem/src/backend/im/mod.rs
+        pub struct ImBackend { decode_mode: RustDecodeMode }
+        impl Default, PathCtx, EventCtx, OwnedEventCtx, BuilderCtx.
+        pub struct ImStringAssembler { scratch: Str, options: BufferOptions }
+        pub struct ImValueAssembler { applicator: ValueApplicator }
+        Include `RustDecodeMode::StrictUnicode` and `RustDecodeMode::ReplaceInvalid`.
+
+    crates/jsonmodem/tests/im_spikes.rs (new, #[cfg(test)])
+        Define focused tests that mutate EcoString and rpds containers, asserting structural sharing and safe mutation patterns.
+        Document observations inline so contributors understand why these behaviours are relied upon in production code.
+
+    crates/jsonmodem/src/jsonmodem_im.rs (new, feature = "im")
+        Provide JsonModemIm and JsonModemImIter types that collect immutable snapshots via standard iterators.
+        Offer constructors (`new`, `with_options`, `with_config`), feed/finish helpers, and snapshot accessors.
+
+    crates/jsonmodem/tests/im_adapter.rs (integration test, required feature)
+        Exercise JsonModemIm using partial snapshots, validating final output stability and iterator behaviour.
+
+    crates/jsonmodem/src/backend/mod.rs and crates/jsonmodem/src/lib.rs
+        Re-export ImBackend, ImStringAssembler, ImValueAssembler, and associated aliases so callers can opt in.
+
+    crates/jsonmodem/tests/jsonmodem_values/tests.rs
+        Add test cases covering ImValueAssembler behaviour, ensuring serde_json parity and partial snapshot correctness.
+
+    docs/im/im-execplan.md
+        Document design goals, dependency choices, safety guarantees, number/string policies, and future extensions.
+
+    .agent/check.sh
+        Ensure local validation enables the `im` feature via `--features im` while keeping crate defaults untouched.
+
+All new or modified code must include succinct comments clarifying non-obvious logic, particularly around persistent container mutations and decode-mode handling, to aid future maintainers.
+
+## Change Notes
+
+2025-02-14 Codex: Replaced previous plan with a PLANS.md-compliant ExecPlan that guides contributors through recreating the immutable backend introduced between HEAD~1 and HEAD.
+2025-02-14 Codex: Expanded the plan to mandate EcoString/rpds spikes, a JsonModemIm prototype, and documentation of experimental findings before full implementation.
+2025-02-14 Codex: Added milestones for feature-gating `JsonModemIm`, updating `.agent/check.sh`, and promoting the immutable adapter to a public API behind `im`.

--- a/plans/im/prompt.md
+++ b/plans/im/prompt.md
@@ -1,0 +1,45 @@
+you will create an execplan to ship the immutable backend for jsonmodem. start from the api below and call out that the immutable snapshots don’t need a lending iterator.
+
+```rs
+use jsonmodem::{
+    BufferOptions, ImBackend, ImValueAssembler, JsonModem, JsonModemBuffers, JsonModemValues,
+    ParserOptions, ValuesOptions,
+};
+
+let mut parser = JsonModem::<ImBackend>::new(ParserOptions::default());
+
+let assembler = ImValueAssembler::new(BufferOptions::default());
+let mut buffers = JsonModemBuffers::with_builder(ParserOptions::default(), assembler.clone());
+let mut values = JsonModemValues::with_buffer_builder(
+    ParserOptions::default(),
+    ValuesOptions::default(),
+    assembler,
+);
+
+#[cfg(feature = "im")]
+{
+    use jsonmodem::JsonModemIm;
+
+    let mut snapshots = JsonModemIm::new();
+    for view in snapshots.feed("{\"title\":\"he") {
+        println!("partial: {}", view.value);
+    }
+    for view in snapshots.feed("llo\"}") {
+        println!("partial: {}", view.value);
+    }
+    for view in snapshots.finish() {
+        if view.is_final {
+            println!("final: {}", view.value);
+        }
+    }
+}
+```
+
+your plan should
+
+clone ecow and rpds into tmp/upstream for research
+build the im backend (value enum, zipper, applicator) under crates/jsonmodem/src/backend/im
+re-export ImBackend, ImValueAssembler, JsonModemIm behind the `im` feature
+document benchmarks comparing Std vs IM adapters
+reuse the QuickCheck suites in crates/jsonmodem/src/tests/property_multivalue.rs and property_partition.rs for im
+detail number/decode mode trade-offs and safety notes in the plan


### PR DESCRIPTION
## Summary
- add immutable backend implementation backed by EcoString strings
- replace path handling with rpds::Vector sharing
- adjust assemblers/tests/docs for new backend

## Testing
- .agent/check.sh
