### PR TITLE
Fix float-to-int conversions for no_std builds

### DIFF
--- a/crates/jsonmodem/src/backend/facet/assembler.rs
+++ b/crates/jsonmodem/src/backend/facet/assembler.rs
@@ -337,25 +337,24 @@ fn write_unsigned(
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::checked_conversions
+    clippy::checked_conversions,
+    clippy::float_arithmetic
 )]
 fn convert_signed(value: f64, allow_coerce: bool) -> Option<i64> {
     if value.is_nan() || value.is_infinite() {
         return None;
     }
-    if value.fract() == 0.0 {
+    if value % 1.0 == 0.0 {
         let rounded = value as i128;
         if rounded >= i64::MIN as i128 && rounded <= i64::MAX as i128 {
             return Some(rounded as i64);
         }
     }
     if allow_coerce {
-        let truncated = value.trunc();
-        if truncated.fract() == 0.0 {
-            let rounded = truncated as i128;
-            if rounded >= i64::MIN as i128 && rounded <= i64::MAX as i128 {
-                return Some(rounded as i64);
-            }
+        let truncated = value - value % 1.0;
+        let rounded = truncated as i128;
+        if rounded >= i64::MIN as i128 && rounded <= i64::MAX as i128 {
+            return Some(rounded as i64);
         }
     }
     None
@@ -367,21 +366,22 @@ fn convert_signed(value: f64, allow_coerce: bool) -> Option<i64> {
     clippy::cast_possible_wrap,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss,
-    clippy::checked_conversions
+    clippy::checked_conversions,
+    clippy::float_arithmetic
 )]
 fn convert_unsigned(value: f64, allow_coerce: bool) -> Option<u64> {
     if !(value.is_finite()) || value < 0.0 {
         return None;
     }
-    if value.fract() == 0.0 {
+    if value % 1.0 == 0.0 {
         let rounded = value as u128;
         if rounded <= u64::MAX as u128 {
             return Some(rounded as u64);
         }
     }
     if allow_coerce {
-        let truncated = value.trunc();
-        if truncated >= 0.0 && truncated.fract() == 0.0 {
+        let truncated = value - value % 1.0;
+        if truncated >= 0.0 {
             let rounded = truncated as u128;
             if rounded <= u64::MAX as u128 {
                 return Some(rounded as u64);

--- a/crates/jsonmodem/src/backend/facet/facet_api.rs
+++ b/crates/jsonmodem/src/backend/facet/facet_api.rs
@@ -249,7 +249,8 @@ macro_rules! impl_numeric_signed {
                 clippy::cast_possible_wrap,
                 clippy::cast_precision_loss,
                 clippy::cast_sign_loss,
-                clippy::checked_conversions
+                clippy::checked_conversions,
+                clippy::float_arithmetic
             )]
             impl ValueDyn for $ty {
                 fn ty_name(&self) -> &'static str {
@@ -283,7 +284,7 @@ macro_rules! impl_numeric_signed {
                 }
 
                 fn write_f64(&mut self, value: f64) -> Result<(), &'static str> {
-                    if value.is_finite() && value.fract() == 0.0 {
+                    if value.is_finite() && value % 1.0 == 0.0 {
                         self.write_i64(value as i64)
                     } else {
                         Err("float does not fit signed")
@@ -309,7 +310,8 @@ macro_rules! impl_numeric_unsigned {
                 clippy::cast_possible_wrap,
                 clippy::cast_precision_loss,
                 clippy::cast_sign_loss,
-                clippy::checked_conversions
+                clippy::checked_conversions,
+                clippy::float_arithmetic
             )]
             impl ValueDyn for $ty {
                 fn ty_name(&self) -> &'static str {
@@ -343,7 +345,7 @@ macro_rules! impl_numeric_unsigned {
                 }
 
                 fn write_f64(&mut self, value: f64) -> Result<(), &'static str> {
-                    if value.is_finite() && value.fract() == 0.0 && value >= 0.0 {
+                    if value.is_finite() && value % 1.0 == 0.0 && value >= 0.0 {
                         self.write_u64(value as u64)
                     } else {
                         Err("float does not fit unsigned")


### PR DESCRIPTION
## Summary
- replace `fract`/`trunc` usage with modulo-based checks in facet assembler
- validate integer floats with `% 1.0` in facet numeric adapters and allow clippy float arithmetic

## Testing
- `cargo build --all --release --workspace --exclude jsonmodem-fuzz --exclude jsonmodem-py`
- `./.agent/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c0553dc4f88320a02cde1574db98fa