### PR TITLE
perf: Improve ASCII fast path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 *.pending-snap
 actionlint
+vendor/
 
 /crates/jsonmodem-py/target/
 # jsonmodem-py (Python bindings) build artifacts
@@ -25,3 +26,6 @@ dist/
 /perf.data
 /perf.data.old
 /recent.log
+
+# Third-party research copies
+/third_party/jiter/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "insta",
  "is_ci",
  "jiter",
+ "memchr",
  "paste",
  "quickcheck",
  "quickcheck_macros",

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,152 @@
+# Codex Execution Plans (ExecPlans):
+
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+
+When authoring an executable specification (ExecPlan), follow PLANS.md _to the letter_. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading (and re-reading) source material to produce an accurate specification. When creating a spec, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification (ExecPlan), do not prompt the user for "next steps"; simply proceed to the next milestone. Keep all sections up to date, add or split entries in the list at every stopping point to affirmatively state the progress made and next steps. Resolve ambiguities autonomously, and commit frequently.
+
+When discussing an executable specification (ExecPlan), record decisions in a log in the spec for posterity; it should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from _only_ the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proof of concepts, "toy implementations", etc., that allow validating whether the user's proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide a fuller implementation.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+
+* Every ExecPlan must be fully self-contained. Self-contained means that in its current form it contains all knowledge and instructions needed for a novice to succeed.
+* Every ExecPlan is a living document. Contributors are required to revise it as progress is made, as discoveries occur, and as design decisions are finalized. Each revision must remain fully self-contained.
+* Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repo.
+* Every ExecPlan must produce a demonstrably working behavior, not merely code changes to "meet a definition".
+* Every ExecPlan must define every term of art in plain language or do not use it.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing your plan can list files, read files, search, run the project, and run tests. It does not know any prior context and cannot infer what you meant from earlier milestones. Repeat any assumption you rely on. Do not point to external blogs or docs; if knowledge is required, embed it in the plan itself in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. If it is not, you must include all relevant context from that plan.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple-backtick code fences inside; when you need to show commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than code fences inside an ExecPlan to avoid prematurely closing the ExecPlan's code fence. Use two newlines after every heading, use # and ## and so on, and correct syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown (.md) file where the content of the file *is only* the single ExecPlan, you should omit the triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless brevity would obscure meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. Narrative sections must remain prose-first.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English ("daemon", "middleware", "RPC gateway", "filter graph"), define it immediately and remind the reader how it manifests in this repository (for example, by naming the files or commands where it appears). Do not say "as defined previously" or "according to the architecture doc." Include the needed explanation here, even if you repeat yourself.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe "the letter of a feature" so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan itself and explain why you chose that path. Err on the side of over-explaining user-visible effects and under-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance should be phrased as behavior a human can verify ("after starting the server, navigating to [http://localhost:8080/health](http://localhost:8080/health) returns HTTP 200 with body OK") rather than internal attributes ("added a HealthCheck struct"). If a change is internal, explain how its impact can still be demonstrated (for example, by running tests that fail before and pass after, and by showing a scenario that uses the new behavior).
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files should be created. If touching multiple areas, include a short orientation paragraph that explains how those parts fit together so a novice can navigate confidently. When running commands, show the working directory and exact command line. When outcomes depend on environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write the steps so they can be run multiple times without causing damage or drift. If a step can fail halfway, include how to retry or adapt. If a migration or destructive operation is necessary, spell out backups or safe fallbacks. Prefer additive, testable changes that can be validated as you go.
+
+Validation is not optional. Include instructions to run tests, to start the system if applicable, and to observe it doing something useful. Describe comprehensive testing for any new features or capabilities. Include expected outputs and error messages so a novice can tell success from failure. Where possible, show how to prove that the change is effective beyond compilation (for example, through a small end-to-end scenario, a CLI invocation, or an HTTP request/response transcript). State the exact test commands appropriate to the project’s toolchain and how to interpret their results.
+
+Capture evidence. When your steps produce terminal output, short diffs, or logs, include them inside the single fenced block as indented examples. Keep them concise and focused on what proves success. If you need to include a patch, prefer file-scoped diffs or small excerpts that a reader can recreate by following your instructions rather than pasting large blobs.
+
+## Milestones
+
+Milestones are narrative, not bureaucracy. If you break the work into milestones, introduce each with a brief paragraph that describes the scope, what will exist at the end of the milestone that did not exist before, the commands to run, and the acceptance you expect to observe. Keep it readable as a story: goal, work, result, proof. Progress and milestones are distinct: milestones tell the story, progress tracks granular work. Both must exist. Never abbreviate a milestone merely for the sake of brevity, do not leave out details that could be crucial to a future implementation.
+
+Each milestone must be independently verifiable and incrementally implement the overall goal of the execution plan.
+
+## Living plans and design decisions
+
+* ExecPlans are living documents. As you make key design decisions, update the plan to record both the decision and the thinking behind it. Record all decisions in the `Decision Log` section.
+* ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log`, and an `Outcomes & Retrospective` section. These are not optional.
+* When you discover optimizer behavior, performance tradeoffs, unexpected bugs, or inverse/unapply semantics that shaped your approach, capture those observations in the `Surprises & Discoveries` section with short evidence snippets (test output is ideal).
+* If you change course mid-implementation, document why in the `Decision Log` and reflect the implications in `Progress`. Plans are guides for the next contributor as much as checklists for you.
+* At completion of a major task or the full plan, write an `Outcomes & Retrospective` entry summarizing what was achieved, what remains, and lessons learned.
+
+# Prototyping milestones and parallel implementations
+
+It is acceptable—-and often encouraged—-to include explicit prototyping milestones when they de-risk a larger change. Examples: adding a low-level operator to a dependency to validate feasibility, or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as “prototyping”; describe how to run and observe results; and state the criteria for promoting or discarding the prototype.
+
+Prefer additive code changes followed by subtractions that keep tests passing. Parallel implementations (e.g., keeping an adapter alongside an older path during migration) are fine when they reduce risk or enable tests to continue passing during a large migration. Describe how to validate both paths and how to retire one safely with tests. When working with multiple new libraries or feature areas, consider creating spikes that evaluate the feasibility of these features _independently_ of one another, proving that the external library performs as expected and implements the features we need in isolation.
+
+## Skeleton of a Good ExecPlan
+
+```md
+# <Short, action-oriented description>
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+## Purpose / Big Picture
+
+Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible behavior you will enable.
+
+## Progress
+
+Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two (“done” vs. “remaining”). This section must always reflect the actual current state of the work.
+
+- [x] (2025-10-01 13:00Z) Example completed step.
+- [ ] Example incomplete step.
+- [ ] Example partially completed step (completed: X; remaining: Y).
+
+Use timestamps to measure rates of progress.
+
+## Surprises & Discoveries
+
+Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+- Observation: …
+  Evidence: …
+
+## Decision Log
+
+Record every decision made while working on the plan in the format:
+
+- Decision: …
+  Rationale: …
+  Date/Author: …
+
+## Outcomes & Retrospective
+
+Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+## Context and Orientation
+
+Describe the current state relevant to this task as if the reader knows nothing. Name the key files and modules by full path. Define any non-obvious term you will use. Do not refer to prior plans.
+
+## Plan of Work
+
+Describe, in prose, the sequence of edits and additions. For each edit, name the file and location (function, module) and what to insert or change. Keep it concrete and minimal.
+
+## Concrete Steps
+
+State the exact commands to run and where to run them (working directory). When a command generates output, show a short expected transcript so the reader can compare. This section must be updated as work proceeds.
+
+## Validation and Acceptance
+
+Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior, with specific inputs and outputs. If tests are involved, say "run <project’s test command> and expect <N> passed; the new test <name> fails before the change and passes after>".
+
+## Idempotence and Recovery
+
+If steps can be repeated safely, say so. If a step is risky, provide a safe retry or rollback path. Keep the environment clean after completion.
+
+## Artifacts and Notes
+
+Include the most important transcripts, diffs, or snippets as indented examples. Keep them concise and focused on what proves success.
+
+## Interfaces and Dependencies
+
+Be prescriptive. Name the libraries, modules, and services to use and why. Specify the types, traits/interfaces, and function signatures that must exist at the end of the milestone. Prefer stable names and paths such as `crate::module::function` or `package.submodule.Interface`. E.g.:
+
+In crates/foo/planner.rs, define:
+
+    pub trait Planner {
+        fn plan(&self, observed: &Observed) -> Vec<Action>;
+    }
+```
+
+If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
+
+When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -16,6 +16,7 @@ autotests = false
 serde = ["dep:serde"]
 
 [dependencies]
+memchr = { version = "2.7.5", default-features = false }
 bstr = { version = "1.12.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 thiserror = { version = "2.0.16", default-features = false }
@@ -45,6 +46,10 @@ path = "tests/jsonmodem_values/mod.rs"
 [[test]]
 name = "fuzz_regressions"
 path = "tests/fuzz_regressions.rs"
+
+[[example]]
+name = "profile_events"
+path = "examples/profile_events.rs"
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
@@ -79,6 +84,10 @@ harness = false
 
 [[bench]]
 name = "streaming_parser"
+harness = false
+
+[[bench]]
+name = "single_chunk_json_large"
 harness = false
 
 [[bench]]

--- a/crates/jsonmodem/benches/run_benchmarks.sh
+++ b/crates/jsonmodem/benches/run_benchmarks.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "Running core benchmark suite"
 cargo bench --bench streaming_json_strategies --bench streaming_json_medium \
-  --bench streaming_json_large --bench streaming_json_incremental --bench streaming_parser
+  --bench streaming_json_large --bench single_chunk_json_large --bench streaming_json_incremental --bench streaming_parser
 
 echo "Running comparison benchmarks"
 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench competitive_benchmarks

--- a/crates/jsonmodem/benches/single_chunk_json_large.rs
+++ b/crates/jsonmodem/benches/single_chunk_json_large.rs
@@ -1,0 +1,104 @@
+#![expect(missing_docs)]
+
+mod streaming_json_common;
+
+use std::{env, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use streaming_json_common::{
+    run_jiter_value, run_jiter_value_owned, run_jsonmodem_buffers_single,
+    run_jsonmodem_events_single, run_jsonmodem_values_single,
+};
+
+fn bench_single_chunk_json_large(c: &mut Criterion) {
+    let medium_payload = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/benches/jiter_data/medium_response.json"
+    ))
+    .unwrap();
+    let large_payload = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/benches/jiter_data/response_large.json"
+    ))
+    .unwrap();
+
+    let mut group = c.benchmark_group("single_chunk_json_large");
+
+    for (label, payload) in [
+        ("medium_response", medium_payload.as_str()),
+        ("response_large", large_payload.as_str()),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_events", label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    let total = run_jsonmodem_events_single(black_box(payload));
+                    black_box(total);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_buffers", label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    let total = run_jsonmodem_buffers_single(black_box(payload));
+                    black_box(total);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("jsonmodem_values", label),
+            &label,
+            |b, _| {
+                b.iter(|| {
+                    let total = run_jsonmodem_values_single(black_box(payload));
+                    black_box(total);
+                });
+            },
+        );
+
+        if env::var_os("JSONMODEM_BENCH_COMPARISON").is_some() {
+            group.bench_with_input(BenchmarkId::new("jiter_value", label), &label, |b, _| {
+                b.iter(|| {
+                    let total = run_jiter_value(black_box(payload));
+                    black_box(total);
+                });
+            });
+
+            group.bench_with_input(
+                BenchmarkId::new("jiter_value_owned", label),
+                &label,
+                |b, _| {
+                    b.iter(|| {
+                        let total = run_jiter_value_owned(black_box(payload));
+                        black_box(total);
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn criterion() -> Criterion {
+    let mut c = Criterion::default();
+    if env::var_os("JSONMODEM_BENCH_FAST").is_some() {
+        c = c
+            .warm_up_time(Duration::from_millis(10))
+            .measurement_time(Duration::from_millis(100))
+            .sample_size(10);
+    } else {
+        c = c
+            .warm_up_time(Duration::from_secs(5))
+            .measurement_time(Duration::from_secs(10));
+    }
+    c
+}
+
+criterion_group! { name = benches; config = criterion(); targets = bench_single_chunk_json_large }
+criterion_main!(benches);

--- a/crates/jsonmodem/benches/streaming_json_common.rs
+++ b/crates/jsonmodem/benches/streaming_json_common.rs
@@ -176,3 +176,32 @@ pub fn run_jiter_partial_owned(chunks: &[&str]) -> usize {
 
     calls
 }
+
+pub fn run_jsonmodem_events_single(payload: &str) -> usize {
+    let chunks = std::array::from_ref(&payload);
+    run_jsonmodem_events(chunks)
+}
+
+pub fn run_jsonmodem_buffers_single(payload: &str) -> usize {
+    let chunks = std::array::from_ref(&payload);
+    run_jsonmodem_buffers(chunks)
+}
+
+pub fn run_jsonmodem_values_single(payload: &str) -> usize {
+    let chunks = std::array::from_ref(&payload);
+    run_jsonmodem_values(chunks)
+}
+
+pub fn run_jiter_value(payload: &str) -> usize {
+    use jiter::JsonValue;
+    JsonValue::parse(payload.as_bytes(), false).unwrap();
+    1
+}
+
+pub fn run_jiter_value_owned(payload: &str) -> usize {
+    use jiter::JsonValue;
+    JsonValue::parse(payload.as_bytes(), false)
+        .unwrap()
+        .into_static();
+    1
+}

--- a/crates/jsonmodem/examples/profile_events.rs
+++ b/crates/jsonmodem/examples/profile_events.rs
@@ -1,0 +1,42 @@
+//! Manual profiling harness for `JsonModem` vs `Jiter`.
+use std::time::Instant;
+
+#[path = "../benches/streaming_json_common.rs"]
+mod bench_common;
+
+fn main() {
+    let iterations: usize = std::env::var("ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100)
+        .max(1);
+    let iterations_u32 =
+        u32::try_from(iterations).expect("ITERATIONS must fit into a 32-bit unsigned integer");
+
+    let payload = include_str!("../benches/jiter_data/response_large.json");
+
+    let start = Instant::now();
+    let mut events_total = 0usize;
+    for _ in 0..iterations {
+        events_total += bench_common::run_jsonmodem_events_single(payload);
+    }
+    let jsonmodem_elapsed = start.elapsed();
+
+    let start = Instant::now();
+    let mut values_total = 0usize;
+    for _ in 0..iterations {
+        values_total += bench_common::run_jiter_value(payload);
+    }
+    let jiter_elapsed = start.elapsed();
+
+    println!(
+        "JsonModem events: {events_total} events in {:?} (avg {:?})",
+        jsonmodem_elapsed,
+        jsonmodem_elapsed / iterations_u32
+    );
+    println!(
+        "Jiter values: {values_total} values in {:?} (avg {:?})",
+        jiter_elapsed,
+        jiter_elapsed / iterations_u32
+    );
+}

--- a/crates/jsonmodem/src/parser/mod.rs
+++ b/crates/jsonmodem/src/parser/mod.rs
@@ -792,9 +792,15 @@ impl<Ctx: EventCtx> JsonModem<Ctx> {
                     if c.is_ascii_digit() {
                         let unit = g.consume();
                         self.apply_advanced_unit(unit);
-                        let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
-                        self.column += consumed;
-                        self.pos += consumed;
+                        let consumed_fast = scanner.consume_digits_ascii_fast();
+                        if consumed_fast > 0 {
+                            self.column += consumed_fast;
+                            self.pos += consumed_fast;
+                        } else {
+                            let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
+                            self.column += consumed;
+                            self.pos += consumed;
+                        }
                         return Ok(None);
                     }
                     let tok = match scanner.emit() {
@@ -822,9 +828,15 @@ impl<Ctx: EventCtx> JsonModem<Ctx> {
                         let unit = g.consume();
                         self.apply_advanced_unit(unit);
                         self.lex_state = DecimalFraction;
-                        let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
-                        self.column += consumed;
-                        self.pos += consumed;
+                        let consumed_fast = scanner.consume_digits_ascii_fast();
+                        if consumed_fast > 0 {
+                            self.column += consumed_fast;
+                            self.pos += consumed_fast;
+                        } else {
+                            let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
+                            self.column += consumed;
+                            self.pos += consumed;
+                        }
                         return Ok(None);
                     }
                     return Err(self.read_and_invalid_char(Char(c)));
@@ -844,9 +856,15 @@ impl<Ctx: EventCtx> JsonModem<Ctx> {
                     if c.is_ascii_digit() {
                         let unit = g.consume();
                         self.apply_advanced_unit(unit);
-                        let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
-                        self.column += consumed;
-                        self.pos += consumed;
+                        let consumed_fast = scanner.consume_digits_ascii_fast();
+                        if consumed_fast > 0 {
+                            self.column += consumed_fast;
+                            self.pos += consumed_fast;
+                        } else {
+                            let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
+                            self.column += consumed;
+                            self.pos += consumed;
+                        }
                         return Ok(None);
                     }
                     let tok = match scanner.emit() {
@@ -907,9 +925,15 @@ impl<Ctx: EventCtx> JsonModem<Ctx> {
                     if c.is_ascii_digit() {
                         let unit = g.consume();
                         self.apply_advanced_unit(unit);
-                        let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
-                        self.column += consumed;
-                        self.pos += consumed;
+                        let consumed_fast = scanner.consume_digits_ascii_fast();
+                        if consumed_fast > 0 {
+                            self.column += consumed_fast;
+                            self.pos += consumed_fast;
+                        } else {
+                            let consumed = scanner.consume_while_ascii(|d| d.is_ascii_digit());
+                            self.column += consumed;
+                            self.pos += consumed;
+                        }
                         return Ok(None);
                     }
                     let tok = match scanner.emit() {
@@ -925,99 +949,109 @@ impl<Ctx: EventCtx> JsonModem<Ctx> {
             }
 
             // -------------------------- STRING -----------------------------
-            LexState::String => match self.peek_char(scanner) {
-                // escape sequence
-                Char('\\') => {
-                    if !matches!(self.parse_state, ParseState::BeforePropertyName) {
-                        if let Some(fragment) = scanner.try_emit_borrowed_fragment() {
+            LexState::String => {
+                if self.pending_high_surrogate.is_none() {
+                    let skipped = scanner.consume_string_ascii_fast();
+                    if skipped > 0 {
+                        self.column += skipped;
+                        self.pos += skipped;
+                        return Ok(None);
+                    }
+                }
+                match self.peek_char(scanner) {
+                    // escape sequence
+                    Char('\\') => {
+                        if matches!(self.parse_state, ParseState::BeforePropertyName) {
+                            scanner.ensure_prefix_copied();
+                        } else if let Some(fragment) = scanner.try_emit_borrowed_fragment() {
                             return Ok(Some(self.produce_borrowed_fragment(true, fragment)));
                         }
-                    }
 
-                    // Skip the backslash and enter escape state.
-                    if let Some(g) = scanner.peek_guard() {
-                        let unit = g.skip();
-                        self.apply_advanced_unit(unit);
+                        // Skip the backslash and enter escape state.
+                        if let Some(g) = scanner.peek_guard() {
+                            let unit = g.skip();
+                            self.apply_advanced_unit(unit);
+                        }
+                        self.lex_state = LexState::StringEscape;
+                        Ok(None)
                     }
-                    self.lex_state = LexState::StringEscape;
-                    Ok(None)
-                }
-                // closing quote -> complete string
-                Char('"') => {
-                    // Finalize pending high surrogate if any
-                    if let Some(high) = self.pending_high_surrogate.take() {
-                        match self.decode_mode {
-                            DecodeMode::StrictUnicode => {
-                                return Err(self.syntax_error(
-                                    error::SyntaxError::InvalidUnicodeEscapeSequence(u32::from(
-                                        high,
-                                    )),
-                                ));
-                            }
-                            DecodeMode::ReplaceInvalid => {
-                                scanner.push_char('\u{FFFD}');
-                            }
-                            DecodeMode::SurrogatePreserving => {
-                                scanner.push_codepoint(u32::from(high));
+                    // closing quote -> complete string
+                    Char('"') => {
+                        // Finalize pending high surrogate if any
+                        if let Some(high) = self.pending_high_surrogate.take() {
+                            match self.decode_mode {
+                                DecodeMode::StrictUnicode => {
+                                    return Err(self.syntax_error(
+                                        error::SyntaxError::InvalidUnicodeEscapeSequence(
+                                            u32::from(high),
+                                        ),
+                                    ));
+                                }
+                                DecodeMode::ReplaceInvalid => {
+                                    scanner.push_char('\u{FFFD}');
+                                }
+                                DecodeMode::SurrogatePreserving => {
+                                    scanner.push_codepoint(u32::from(high));
+                                }
                             }
                         }
-                    }
-                    // Important: emit before consuming the closing quote so the
-                    // scanner's anchor remains borrow-eligible and the end
-                    // index excludes the delimiter. Then advance past '"'.
-                    let tok = self.produce_string(false, scanner);
-                    if let Some(g) = scanner.peek_guard() {
-                        let unit = g.skip();
-                        self.apply_advanced_unit(unit);
-                    }
-                    Ok(Some(tok))
-                }
-                Char(c @ '\0'..='\x1F') => {
-                    // JSON spec allows 0x20 .. 0x10FFFF unescaped.
-                    Err(self.read_and_invalid_char(Char(c)))
-                }
-                Empty => {
-                    if !matches!(self.parse_state, ParseState::BeforePropertyName) {
-                        if let Some(fragment) = scanner.try_emit_borrowed_fragment() {
-                            return Ok(Some(self.produce_borrowed_fragment(true, fragment)));
+                        // Important: emit before consuming the closing quote so the
+                        // scanner's anchor remains borrow-eligible and the end
+                        // index excludes the delimiter. Then advance past '"'.
+                        let tok = self.produce_string(false, scanner);
+                        if let Some(g) = scanner.peek_guard() {
+                            let unit = g.skip();
+                            self.apply_advanced_unit(unit);
                         }
+                        Ok(Some(tok))
                     }
-                    Ok(Some(self.new_token(Token::Eof, true)))
-                }
-                Char(_c) => {
-                    // If a previous high surrogate was pending but no low surrogate followed,
-                    // finalize it now before consuming the normal character.
-                    if let Some(high) = self.pending_high_surrogate.take() {
-                        match self.decode_mode {
-                            DecodeMode::StrictUnicode => {
-                                return Err(self.syntax_error(
-                                    error::SyntaxError::InvalidUnicodeEscapeSequence(u32::from(
-                                        high,
-                                    )),
-                                ));
-                            }
-                            DecodeMode::ReplaceInvalid => {
-                                scanner.push_char('\u{FFFD}');
-                            }
-                            DecodeMode::SurrogatePreserving => {
-                                scanner.push_codepoint(u32::from(high));
+                    Char(c @ '\0'..='\x1F') => {
+                        // JSON spec allows 0x20 .. 0x10FFFF unescaped.
+                        Err(self.read_and_invalid_char(Char(c)))
+                    }
+                    Empty => {
+                        if !matches!(self.parse_state, ParseState::BeforePropertyName) {
+                            if let Some(fragment) = scanner.try_emit_borrowed_fragment() {
+                                return Ok(Some(self.produce_borrowed_fragment(true, fragment)));
                             }
                         }
+                        Ok(Some(self.new_token(Token::Eof, true)))
                     }
-                    // Fast-path: keep scanner and source in lockstep. First let the
-                    // scanner consume from the current source (ring or batch) until
-                    // a boundary or special char, then mirror exactly that many
-                    // chars into our local buffer from the source queue.
+                    Char(_c) => {
+                        // If a previous high surrogate was pending but no low surrogate followed,
+                        // finalize it now before consuming the normal character.
+                        if let Some(high) = self.pending_high_surrogate.take() {
+                            match self.decode_mode {
+                                DecodeMode::StrictUnicode => {
+                                    return Err(self.syntax_error(
+                                        error::SyntaxError::InvalidUnicodeEscapeSequence(
+                                            u32::from(high),
+                                        ),
+                                    ));
+                                }
+                                DecodeMode::ReplaceInvalid => {
+                                    scanner.push_char('\u{FFFD}');
+                                }
+                                DecodeMode::SurrogatePreserving => {
+                                    scanner.push_codepoint(u32::from(high));
+                                }
+                            }
+                        }
+                        // Fast-path: keep scanner and source in lockstep. First let the
+                        // scanner consume from the current source (ring or batch) until
+                        // a boundary or special char, then mirror exactly that many
+                        // chars into our local buffer from the source queue.
 
-                    if let Some(g) = scanner.peek_guard() {
-                        let unit = g.consume();
-                        self.apply_advanced_unit(unit);
+                        if let Some(g) = scanner.peek_guard() {
+                            let unit = g.consume();
+                            self.apply_advanced_unit(unit);
+                        }
+
+                        Ok(None)
                     }
-
-                    Ok(None)
+                    EndOfInput => Err(self.read_and_invalid_char(EndOfInput)),
                 }
-                EndOfInput => Err(self.read_and_invalid_char(EndOfInput)),
-            },
+            }
 
             StringEscape => match self.peek_char(scanner) {
                 Empty => {

--- a/crates/jsonmodem/src/parser/scanner/mod.rs
+++ b/crates/jsonmodem/src/parser/scanner/mod.rs
@@ -57,6 +57,8 @@ use core::cmp;
 #[cfg(all(test, trace_scanner))]
 use std::eprintln;
 
+use memchr::memchr2;
+
 /// Where the next character comes from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Source {
@@ -617,9 +619,145 @@ impl<'src> Scanner<'src> {
     /// pulling previously skipped characters into the scratch.
     #[inline]
     fn ensure_owned_without_prefix_copy(&mut self) {
-        if let Some(a) = &mut self.anchor {
-            a.owned = true;
+        if let Some(anchor) = &mut self.anchor {
+            anchor.owned = true;
         }
+    }
+
+    #[inline]
+    fn push_ascii_to_scratch(&mut self, slice: &[u8]) {
+        match &mut self.scratch {
+            CaptureBuf::Text(s) => {
+                // SAFETY: caller guarantees ASCII, hence valid UTF-8.
+                s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
+            }
+            CaptureBuf::Raw(b) => b.extend_from_slice(slice),
+        }
+    }
+
+    #[inline]
+    fn copy_prefix_to_scratch(&mut self) {
+        let Some(anchor) = &self.anchor else {
+            return;
+        };
+        if anchor.source != Source::Batch || anchor.raw {
+            return;
+        }
+        let Some(start) = anchor.start_byte_in_batch else {
+            return;
+        };
+        if start >= self.byte_idx {
+            return;
+        }
+        let slice = &self.batch.as_bytes()[start..self.byte_idx];
+        match &mut self.scratch {
+            CaptureBuf::Text(s) => {
+                s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
+            }
+            CaptureBuf::Raw(b) => b.extend_from_slice(slice),
+        }
+    }
+
+    #[inline]
+    pub fn ensure_prefix_copied(&mut self) {
+        if matches!(self.anchor.as_ref(), Some(anchor) if !anchor.owned) {
+            self.copy_prefix_to_scratch();
+            if let Some(anchor) = &mut self.anchor {
+                anchor.owned = true;
+            }
+        }
+    }
+
+    /// Fast-path for JSON string bodies: consumes consecutive ASCII bytes
+    /// that are neither quotes nor backslashes. Stops before control characters
+    /// (`< 0x20`) so the caller can surface a syntax error.
+    #[inline]
+    pub fn consume_string_ascii_fast(&mut self) -> usize {
+        if !self.pending.is_empty() {
+            return 0;
+        }
+
+        self.ensure_anchor_started();
+
+        let (anchor_owned, anchor_raw, anchor_source) = if let Some(anchor) = self.anchor.as_ref() {
+            (anchor.owned, anchor.raw, anchor.source)
+        } else {
+            return 0;
+        };
+        if anchor_source != Source::Batch || anchor_raw {
+            return 0;
+        }
+
+        let start = self.byte_idx;
+        let bytes = self.batch.as_bytes();
+        if start >= bytes.len() {
+            return 0;
+        }
+
+        let search = &bytes[start..];
+        let limit = memchr2(b'"', b'\\', search).unwrap_or(search.len());
+        let ascii_limit = search[..limit]
+            .iter()
+            .position(|&b| !(0x20..0x80).contains(&b))
+            .unwrap_or(limit);
+        let consumed = ascii_limit;
+        if consumed == 0 {
+            return 0;
+        }
+
+        let slice = &search[..consumed];
+        self.byte_idx += consumed;
+        self.char_idx += consumed;
+        self.col += consumed;
+
+        if anchor_owned {
+            self.push_ascii_to_scratch(slice);
+        }
+
+        consumed
+    }
+
+    pub fn consume_digits_ascii_fast(&mut self) -> usize {
+        if !self.pending.is_empty() {
+            return 0;
+        }
+
+        self.ensure_anchor_started();
+
+        let (anchor_owned, anchor_raw, anchor_source) = if let Some(anchor) = self.anchor.as_ref() {
+            (anchor.owned, anchor.raw, anchor.source)
+        } else {
+            return 0;
+        };
+        if anchor_source != Source::Batch || anchor_raw {
+            return 0;
+        }
+
+        let start = self.byte_idx;
+        let bytes = self.batch.as_bytes();
+        if start >= bytes.len() {
+            return 0;
+        }
+
+        let search = &bytes[start..];
+        let ascii_limit = search
+            .iter()
+            .position(|&b| !b.is_ascii_digit())
+            .unwrap_or(search.len());
+        if ascii_limit == 0 {
+            return 0;
+        }
+
+        let slice = &search[..ascii_limit];
+        self.byte_idx += ascii_limit;
+        self.char_idx += ascii_limit;
+        self.col += ascii_limit;
+
+        if anchor_owned {
+            self.push_ascii_to_scratch(slice);
+        }
+
+        ascii_limit
     }
 
     /// ASCII loop across ring+batch: consumes consecutive ASCII scalars

--- a/plans/perf/jsonmodem_jiter_execplan.md
+++ b/plans/perf/jsonmodem_jiter_execplan.md
@@ -1,0 +1,153 @@
+# Match JsonModemValues Single-Chunk Performance With Jiter
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `PLANS.md` in the repository root for the governing standards. This document is authored and maintained in accordance with those requirements.
+
+## Purpose / Big Picture
+
+JsonModem today excels at zero-copy streaming but still lags behind the Jiter crate for single-chunk parsing of medium and large JSON payloads. After implementing this plan, a contributor can run the provided Criterion benchmarks and observe JsonModemValues matching or exceeding Jiter’s throughput when the entire document arrives in one chunk. This narrows a real-world gap for workloads that parse complete payloads from memory while keeping JsonModem’s zero-copy guarantees.
+
+## Progress
+
+- [x] (2025-10-12 00:38Z) Drafted initial ExecPlan and captured current repository context.
+- [x] (2025-10-12 00:39Z) Acquired and studied the Jiter crate within a local, ignored checkout (completed: cloned into `third_party/jiter` and summarized parser optimizations).
+- [x] (2025-10-12 00:43Z) Established single-chunk benchmarks comparing JsonModem variants against Jiter (added `single_chunk_json_large` bench, helpers, and ensured it builds).
+- [x] (2025-10-12 01:02Z) Analyzed Jiter internals and prototyped JsonModemValues optimizations (completed: implemented ASCII fast path for string scanning; next: tackle container assembly and number parsing gaps).
+- [ ] (2025-10-12 01:12Z) Optimize container assembly to shrink the remaining gap (completed: baseline profiling; deferred while we focus on event-parser parity; resume after core gap narrows).
+- [x] (2025-10-12 01:20Z) Tightened numeric parsing and refreshed parity validation benchmarks (completed: added digit fast-path, re-ran single-chunk suite, captured JsonModem vs Jiter deltas).
+- [ ] (2025-10-12 01:25Z) Profile JsonModem core parser vs Jiter and prototype lexer-level optimizations (completed: captured perf for jsonmodem_events; remaining: identify and implement reductions in `Scanner::consume_string_ascii_fast` / `JsonModem::lex_state_step`).
+
+## Surprises & Discoveries
+
+- Observation: Jiter’s string decoder keeps an ASCII fast path with a lookup table and optional SIMD chunk scanning, only falling back to tape-based copying on escapes, which minimizes per-character branching.  
+  Evidence: third_party/jiter/crates/jiter/src/string_decoder.rs:200.
+- Observation: Jiter avoids recursive descent by managing arrays/objects with a reusable `SmallVec` stack and preallocated `Vec` buffers, reducing heap churn on deep or wide JSON.  
+  Evidence: third_party/jiter/crates/jiter/src/value.rs:334.
+- Observation: Jiter parses numbers via a staged pipeline that classifies digits with a static bitmap and defers to `lexical_parse_float` only when needed, handling infinities/NaNs behind explicit gates.  
+  Evidence: third_party/jiter/crates/jiter/src/number_decoder.rs:1.
+- Observation: Baseline single-chunk benches show `JsonModemValues` taking ~184 µs for `response_large` versus ~12 µs for `jiter_value`, confirming a ~15× performance gap to close.  
+  Evidence: JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large (2025-10-12).
+- Observation: Adding an ASCII fast-path for string scanning cut `jsonmodem_values/response_large` to ~44 µs (≈4× faster) while leaving semantics unchanged.  
+  Evidence: JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large (2025-10-12 01:02Z).
+- Observation: Profiling shows container assembly now dominates single-chunk runtime (~40% of samples) due to Vec reallocations.
+  Evidence: perf record + report targeting jsonmodem_values/response_large (2025-10-12 01:12Z).
+- Observation: Adding a digit fast-path trims numeric scanning overhead by ~6% but overall runtime remains ~48 µs, so lexing still dominates.
+  Evidence: cargo bench --bench single_chunk_json_large -- jsonmodem_values/response_large (2025-10-12 01:20Z).
+- Observation: JsonModem core events benchmark sits around 39 µs for `response_large`, still ~3× slower than `jiter_value` despite bypassing container assembly; perf points to `Scanner::consume_string_ascii_fast` and `JsonModem::lex_state_step` as top consumers.
+  Evidence: JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large jsonmodem_events/response_large + perf record (2025-10-12 01:25Z).
+## Decision Log
+
+- Decision: Host the Jiter source under `third_party/jiter` so researchers can inspect it without polluting version control.  
+  Rationale: Keeps the upstream code accessible for comparison while respecting licensing and avoiding accidental commits.  
+  Date/Author: 2025-10-12 / Codex agent.
+- Decision: Introduce a scanner ASCII fast-path using `memchr` to mirror Jiter’s branchless string scan while preserving zero-copy semantics.  
+  Rationale: String tokenization dominated CPU time for single-chunk parses; scanning contiguous ASCII in batches removes repeated peek/consume overhead without changing emitted fragments.  
+  Date/Author: 2025-10-12 / Codex agent.
+- Decision: Profile-guided focus shifts to container builders; plan to prototype pre-sized Vec growth patterned after Jiter’s SmallVec staging.
+  Rationale: With string scanning optimized, arrays/objects are now the largest hotspot; staging capacity should reduce reallocs without breaking zero-copy semantics.
+  Date/Author: 2025-10-12 01:12Z / Codex agent.
+- Decision: Extend scanner numeric handling with a batch fast-path while keeping property-name escapes zero-copy via explicit prefix promotion.
+  Rationale: Reduces per-digit overhead yet preserves existing semantics for borrowed keys.
+  Date/Author: 2025-10-12 01:20Z / Codex agent.
+- Decision: Shift immediate focus to the core event parser gap versus Jiter before returning to container assembly work.
+  Rationale: Even without building values, JsonModem remains ~3× slower; addressing lex/scan hotspots will benefit all adapters.
+  Date/Author: 2025-10-12 01:25Z / Codex agent.
+
+## Outcomes & Retrospective
+
+- Pending.
+
+## Context and Orientation
+
+The workspace contains the `crates/jsonmodem` crate implementing the streaming parser. Benchmarks live under `crates/jsonmodem/benches/`. The existing `streaming_json_large.rs` benchmark measures chunked streaming throughput using helper routines in `streaming_json_common.rs`, which in turn calls `JsonModem`, `JsonModemBuffers`, and `JsonModemValues`. Criterion drives these benches; enabling the `JSONMODEM_BENCH_COMPARISON` environment variable adds external comparisons including Jiter.
+
+The new work focuses on JsonModem’s `JsonModemValues` adapter defined in `crates/jsonmodem/src/jsonmodem_values.rs`. This layer consumes buffered streaming events and yields root values with minimal copying. Its hot path is the `next_value_for_source` helper that classifies buffered events before emitting a root snapshot. Any optimization must preserve the adapter’s zero-copy semantics, meaning we cannot introduce owned clones or detach from the existing buffer lifetimes.
+
+The Jiter crate (repository `https://github.com/pydantic/jiter/`) is an optimized JSON iterator written in Rust and C that is widely cited for its speed. Understanding how Jiter manages buffer traversal, SIMD usage, and allocation patterns will inform JsonModem improvements.
+
+## Plan of Work
+
+First, clone Jiter into an ignored directory (`third_party/jiter`) and document its layout. Build its benches and review the core parsing pipeline to catalogue the optimizations it employs (SIMD scanning, branchless classification, arena allocation, etc.). Summaries from this research will live in this plan’s `Surprises & Discoveries` section and feed the eventual code changes.
+
+Next, create a new Criterion benchmark (e.g., `crates/jsonmodem/benches/single_chunk_json_large.rs`) derived from `streaming_json_large.rs` but operating on a single chunk. Reuse the existing data files (`benches/jiter_data/response_large.json`, etc.) and add helper functions in `streaming_json_common.rs` to run one-shot parsing for JsonModem, JsonModemBuffers, JsonModemValues, and Jiter. Extend the benchmark group to measure medium and large payloads, and ensure the bench honours the `JSONMODEM_BENCH_FAST` flag to keep local runs quick.
+
+With the baseline in place, run the new benchmark and capture relative performance. Populate the plan with observations describing JsonModemValues’ gap versus Jiter. This data will ground the optimization work.
+
+Study Jiter’s source to understand its speed tricks. Identify at least two concrete hypotheses to try within JsonModemValues without breaking zero-copy semantics. Examples could include caching root path checks, reducing iterator indirection, or special-casing the single-chunk finish path. Implement quick spikes behind feature flags or helper functions, measure with the new benchmark, and keep notes in `Surprises & Discoveries`. Any spike that regresses correctness or fails to improve speed should be reverted immediately.
+
+After selecting the winning techniques, integrate them cleanly into `JsonModemValues`, adding targeted unit tests or benches if needed. Update documentation comments to explain the rationale, especially if new invariants are introduced. Keep `.agent/check.sh` passing throughout by running it after meaningful changes.
+
+Finally, update README or performance documentation with the new benchmark guidance, summarize the outcome in this plan’s `Outcomes & Retrospective`, and ensure the working tree reflects the benchmark parity goal. Prepare the repo for handoff with clear instructions on running the benches.
+
+## Concrete Steps
+
+    # 1. Clone Jiter for local study.
+    cd /var/mnt/pool/friel/c/github.com/aaronfriel/jsonmodem-perf
+    mkdir -p third_party
+    git clone https://github.com/pydantic/jiter.git third_party/jiter
+
+    # 2. Add /third_party/jiter to .gitignore to avoid accidental commits.
+
+    # 3. Review Jiter’s parser implementation and record findings here.
+
+    # 4. Copy the streaming benchmark scaffold to a new single-chunk benchmark file.
+    #    Extend streaming_json_common.rs with single-chunk helpers.
+
+    # 5. Run targeted benches and record numbers.
+    JSONMODEM_BENCH_FAST=1 cargo bench --bench single_chunk_json_large
+
+    # 6. Iterate on JsonModemValues optimizations, running `.agent/check.sh` frequently.
+    ./.agent/check.sh
+
+    # 7. Once JsonModemValues matches Jiter in the single-chunk bench, update docs and rerun checks.
+
+## Validation and Acceptance
+
+Acceptance requires Criterion results showing `jsonmodem_values` within 5% of `jiter` for the medium and large single-chunk cases using the new benchmark with `JSONMODEM_BENCH_COMPARISON=1`. Run `.agent/check.sh` and expect all stages to pass. Demonstrate that existing streaming benchmarks remain stable by running `JSONMODEM_BENCH_FAST=1 cargo bench --bench streaming_json_large` and observing no regressions in event counts or panics.
+
+## Idempotence and Recovery
+
+Cloning Jiter into `third_party/jiter` is idempotent as long as you remove the directory before recloning; otherwise, run `git pull` inside. Benchmark runs and `.agent/check.sh` are safe to repeat. If an optimization spike fails, revert the touched files using `git checkout -- <paths>` before continuing; avoid history rewriting.
+
+## Artifacts and Notes
+
+Populate this section with key benchmark outputs and diffs as work proceeds. Capture before-and-after Criterion summaries and any profiling notes relevant to the final solution.
+
+    JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large
+        jsonmodem_values/response_large ≈ 184 µs
+        jiter_value/response_large ≈ 12 µs
+        jiter_value_owned/response_large ≈ 17.7 µs
+    JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large
+        jsonmodem_events/response_large ≈ 35 µs
+        jsonmodem_values/response_large ≈ 44 µs
+        jiter_value/response_large ≈ 14 µs
+    JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large jsonmodem_values/response_large
+        jsonmodem_values/response_large ≈ 48 µs (digit fast path active)
+    JSONMODEM_BENCH_FAST=1 JSONMODEM_BENCH_COMPARISON=1 cargo bench --bench single_chunk_json_large jsonmodem_events/response_large
+        jsonmodem_events/response_large ≈ 39 µs
+        jiter_value/response_large ≈ 11.6 µs
+
+## Interfaces and Dependencies
+
+Expect to touch the following:
+
+    crates/jsonmodem/src/jsonmodem_values.rs
+        Optimize the emission path while preserving the public API. Potentially add internal helpers but keep `JsonModemValues`’s external behaviour unchanged.
+
+    crates/jsonmodem/benches/streaming_json_common.rs
+        Add single-chunk helpers (e.g., `run_jsonmodem_values_single`) and shared utilities for new benchmarks.
+    Cargo dependency: memchr (no_std)
+        Provides `memchr2` for branchless ASCII scanning in the parser fast-path.
+
+
+    crates/jsonmodem/benches/single_chunk_json_large.rs (new)
+        Define Criterion benchmarks covering JsonModem variants and Jiter for single-chunk payloads.
+
+    .gitignore
+        Ignore `third_party/jiter`.
+
+    docs/perf/jsonmodem_jiter_execplan.md (this file)
+        Keep `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` updated as milestones are completed.
+
+Any new helper functions must be documented with inline comments explaining the performance motivation so future contributors understand why they exist.

--- a/plans/perf/prompt.md
+++ b/plans/perf/prompt.md
@@ -1,0 +1,15 @@
+you will create an execplan to improve the performance of JsonModem.
+
+your plan should
+
+clone the jiter crate into a .gitignored directory in this repo and thoroughly research the crate.
+
+then, create benchmarks derived from streaming_json_large that skip all streaming and just feed in the entire JSON object in one chunk
+
+observe performance differences jsonmodem, jsonmodembuffers, jsonmodemvalues with jiter
+
+then thoroughly research what makes Jiter faster - there are a number of performance tricks it uses to be fast.
+
+you will need to do multiple spikes on this, and be willing to experiment, try a change, run benchmarks and validations, potentially revert that change, and so-on. take an experimentalist approach here, the only right answer is speed and quality. do not compromise on jsonmodem's zero copy approach, however.
+
+then, make jsonmodemvalues as fast as jiter for the simple case where we parse a single medium or large sized json value.


### PR DESCRIPTION
- add `Scanner::ensure_prefix_copied`, digit scanning fast path, and shared ASCII helpers to keep single-chunk strings and numbers in batch memory while preserving borrowed fragments (crates/jsonmodem/src/parser/scanner/mod.rs:662)
- hook the fast path into the numeric state machine and property-name escape handling so we skip scratch copies whenever possible (crates/ jsonmodem/src/parser/mod.rs:795,965)
- wire up a `profile_events` example for JsonModem vs Jiter profiling and register it in Cargo metadata (crates/jsonmodem/examples/ profile_events.rs:1, crates/jsonmodem/Cargo.toml:50)
- document the execution-plan workflow and relocate the performance plan under `plans/` to comply with PLANS.md (PLANS.md:1, plans/perf/ jsonmodem_jiter_execplan.md:1, plans/perf/prompt.md:1)