### PR TITLE
perf: add hotspot benches and flameview optimization report

### DIFF
--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -93,3 +93,7 @@ harness = false
 [[bench]]
 name = "competitive_benchmarks"
 harness = false
+
+[[bench]]
+name = "hotspot_targets"
+harness = false

--- a/crates/jsonmodem/benches/hotspot_targets.rs
+++ b/crates/jsonmodem/benches/hotspot_targets.rs
@@ -1,0 +1,141 @@
+#![expect(missing_docs)]
+
+mod streaming_json_common;
+
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use jsonmodem::{
+    JsonModem, JsonModemBuffers, ParserOptions, StdBackend, lending_iterator::LendingIterator,
+};
+use streaming_json_common::{
+    produce_chunks, run_jsonmodem_events, run_jsonmodem_events_single, run_jsonmodem_values_single,
+};
+
+fn make_ascii_string_payload(bytes: usize) -> String {
+    format!("{{\"k\":\"{}\"}}", "a".repeat(bytes))
+}
+
+fn make_object_payload(fields: usize, value_len: usize) -> String {
+    let mut s = String::with_capacity(fields * (value_len + 20));
+    s.push('{');
+    for i in 0..fields {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('"');
+        s.push('k');
+        s.push_str(&i.to_string());
+        s.push_str("\":\"");
+        s.push_str(&"v".repeat(value_len));
+        s.push('"');
+    }
+    s.push('}');
+    s
+}
+
+fn run_drop_empty_feed_cycles(cycles: usize) -> usize {
+    let options = ParserOptions::default().with_allow_multiple_json_values(true);
+    let mut parser = JsonModem::<StdBackend>::new(options);
+    let mut events = 0usize;
+    for _ in 0..cycles {
+        let mut iter = parser.feed("null ");
+        while let Some(event) = iter.next() {
+            event.unwrap();
+            events += 1;
+        }
+    }
+    let mut iter = parser.finish();
+    while let Some(event) = iter.next() {
+        event.unwrap();
+        events += 1;
+    }
+    events
+}
+
+fn run_buffers_single(payload: &str) -> usize {
+    let mut parser = JsonModemBuffers::<StdBackend, _>::new(
+        ParserOptions::default(),
+        jsonmodem::BufferOptions::default(),
+    );
+    let mut events = 0usize;
+    {
+        let mut iter = parser.feed(payload);
+        while let Some(event) = iter.next() {
+            event.unwrap();
+            events += 1;
+        }
+    }
+    let mut iter = parser.finish();
+    while let Some(event) = iter.next() {
+        event.unwrap();
+        events += 1;
+    }
+    events
+}
+
+fn bench_hotspot_targets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotspot_targets");
+
+    let scanner_payload = make_ascii_string_payload(256 * 1024);
+    group.bench_function("parser_events_ascii_single_chunk_256k", |b| {
+        b.iter(|| {
+            let total = run_jsonmodem_events_single(black_box(scanner_payload.as_str()));
+            black_box(total);
+        });
+    });
+
+    let scanner_chunks = produce_chunks(&scanner_payload, 1024);
+    group.bench_function("parser_events_ascii_cross_chunk_256k_1024", |b| {
+        b.iter(|| {
+            let total = run_jsonmodem_events(black_box(&scanner_chunks));
+            black_box(total);
+        });
+    });
+
+    group.bench_with_input(
+        BenchmarkId::new("iterator_drop_small_value_cycles", 4096usize),
+        &4096usize,
+        |b, &cycles| {
+            b.iter(|| {
+                let total = run_drop_empty_feed_cycles(black_box(cycles));
+                black_box(total);
+            });
+        },
+    );
+
+    let object_payload = make_object_payload(1024, 48);
+    group.bench_function("buffers_object_assembly_1024x48", |b| {
+        b.iter(|| {
+            let total = run_buffers_single(black_box(object_payload.as_str()));
+            black_box(total);
+        });
+    });
+
+    group.bench_function("values_object_assembly_1024x48", |b| {
+        b.iter(|| {
+            let total = run_jsonmodem_values_single(black_box(object_payload.as_str()));
+            black_box(total);
+        });
+    });
+
+    group.finish();
+}
+
+fn criterion() -> Criterion {
+    let mut c = Criterion::default();
+    if std::env::var_os("JSONMODEM_BENCH_FAST").is_some() {
+        c = c
+            .warm_up_time(Duration::from_millis(10))
+            .measurement_time(Duration::from_millis(120))
+            .sample_size(10);
+    } else {
+        c = c
+            .warm_up_time(Duration::from_secs(5))
+            .measurement_time(Duration::from_secs(10));
+    }
+    c
+}
+
+criterion_group! { name = benches; config = criterion(); targets = bench_hotspot_targets }
+criterion_main!(benches);

--- a/crates/jsonmodem/src/backend/std/value_applicator.rs
+++ b/crates/jsonmodem/src/backend/std/value_applicator.rs
@@ -214,11 +214,15 @@ impl ValueApplicator {
         path: &StdPath,
         kind: ContainerKind,
     ) -> AppliedRef<'a> {
-        let (path, leaf) = self.zipper.with_leaf_mut(path, |slot| {
-            *slot = match kind {
-                ContainerKind::Array => Value::Array(Vec::new()),
-                ContainerKind::Object => Value::Object(BTreeMap::default()),
-            };
+        let (path, leaf) = self.zipper.with_leaf_mut(path, |slot| match kind {
+            ContainerKind::Array => match slot {
+                Value::Array(values) => values.clear(),
+                _ => *slot = Value::Array(Vec::new()),
+            },
+            ContainerKind::Object => match slot {
+                Value::Object(map) => map.clear(),
+                _ => *slot = Value::Object(BTreeMap::new()),
+            },
         });
 
         match kind {

--- a/crates/jsonmodem/src/jsonmodem_values.rs
+++ b/crates/jsonmodem/src/jsonmodem_values.rs
@@ -332,6 +332,7 @@ enum EmitKind {
     Final,
 }
 
+#[inline]
 fn classify_event<Ctx>(
     event: &BorrowedBufferedEvent<'_, Ctx>,
     partial_enabled: bool,
@@ -341,11 +342,9 @@ where
     Ctx: BuilderCtx + EventCtx,
     Ctx::Path: PathRoot,
 {
-    let path_is_root = |path: &&Ctx::Path| path.is_root();
-
     match event {
         BorrowedBufferedEvent::String { path, is_final, .. } => {
-            if path_is_root(path) {
+            if path.is_root() {
                 if *is_final {
                     Some(EmitKind::Final)
                 } else {
@@ -366,7 +365,7 @@ where
         | BorrowedBufferedEvent::Null { path }
         | BorrowedBufferedEvent::Boolean { path, .. }
         | BorrowedBufferedEvent::Number { path, .. } => {
-            if path_is_root(path) {
+            if path.is_root() {
                 Some(EmitKind::Final)
             } else {
                 *saw_partial = true;
@@ -376,6 +375,7 @@ where
     }
 }
 
+#[inline]
 fn next_emit_kind<Ctx, S>(
     source: &mut S,
     options: ValuesOptions,

--- a/crates/jsonmodem/src/parser/mod.rs
+++ b/crates/jsonmodem/src/parser/mod.rs
@@ -247,7 +247,12 @@ impl<Ctx: EventCtx> Drop for JsonModemIterator<'_, '_, Ctx> {
         self.parser.path = MaybeUninit::new(self.factory.freeze(thawed));
 
         // Persist scanner carryover (unread tail + token scratch + positions)
-        self.parser.scanner_state = core::mem::take(&mut self.scanner).finish();
+        let scanner = core::mem::take(&mut self.scanner);
+        self.parser.scanner_state = if scanner.can_finish_without_merge() {
+            scanner.into_state()
+        } else {
+            scanner.finish()
+        };
     }
 }
 
@@ -283,7 +288,12 @@ impl<Ctx: EventCtx> Drop for JsonModemClosed<'_, Ctx> {
         self.parser.path = MaybeUninit::new(self.factory.freeze(thawed));
 
         // Persist scanner carryover (unread tail + token scratch + positions)
-        let carry = core::mem::take(&mut self.scanner).finish();
+        let scanner = core::mem::take(&mut self.scanner);
+        let carry = if scanner.can_finish_without_merge() {
+            scanner.into_state()
+        } else {
+            scanner.finish()
+        };
         self.parser.scanner_state = carry;
     }
 }

--- a/crates/jsonmodem/src/parser/scanner/mod.rs
+++ b/crates/jsonmodem/src/parser/scanner/mod.rs
@@ -235,6 +235,30 @@ pub struct Scanner<'src> {
 }
 
 impl<'src> Scanner<'src> {
+    #[inline]
+    pub(crate) fn can_finish_without_merge(&self) -> bool {
+        self.anchor.is_none() && self.byte_idx >= self.batch.len()
+    }
+
+    #[inline]
+    pub(crate) fn into_state(self) -> ScannerState {
+        ScannerState {
+            pending: self.pending,
+            char_idx: self.char_idx,
+            line: self.line,
+            col: self.col,
+            scratch: self.scratch,
+        }
+    }
+
+    #[inline]
+    fn scratch_is_empty(&self) -> bool {
+        match &self.scratch {
+            CaptureBuf::Text(s) => s.is_empty(),
+            CaptureBuf::Raw(b) => b.is_empty(),
+        }
+    }
+
     /// Constructs a new session from prior carryover state and the current
     /// batch.
     ///
@@ -306,6 +330,7 @@ impl<'src> Scanner<'src> {
     ///
     /// Single‑shot: `finish(self)` consumes the session and should be called at
     /// most once per feed.
+    #[inline]
     pub fn finish(mut self) -> ScannerState {
         #[cfg(all(test, trace_scanner))]
         eprintln!(
@@ -321,15 +346,12 @@ impl<'src> Scanner<'src> {
         );
         // If token started in batch and not yet owned, copy prefix into scratch
         // so the next feed can continue in owned mode and emit a single fragment.
+        let scratch_is_empty = self.scratch_is_empty();
         if let Some(anchor) = &mut self.anchor {
             if anchor.source == Source::Batch && !anchor.owned {
                 // Avoid duplicating already consumed characters: if `consume()` has
                 // appended into scratch during this feed, the scratch already contains
                 // the batch prefix. In that case, do not copy again.
-                let scratch_is_empty = match &self.scratch {
-                    CaptureBuf::Text(s) => s.is_empty(),
-                    CaptureBuf::Raw(b) => b.is_empty(),
-                };
                 if scratch_is_empty {
                     if let Some(start) = anchor.start_byte_in_batch {
                         let end = cmp::min(self.byte_idx, self.batch.len());
@@ -344,8 +366,6 @@ impl<'src> Scanner<'src> {
                         }
                     }
                 }
-                // Mark as owned regardless to ensure coherent continuation next feed
-                anchor.owned = true;
             }
         }
 
@@ -361,13 +381,7 @@ impl<'src> Scanner<'src> {
             );
         }
 
-        ScannerState {
-            pending: self.pending,
-            char_idx: self.char_idx,
-            line: self.line,
-            col: self.col,
-            scratch: self.scratch,
-        }
+        self.into_state()
     }
 
     /// Decodes but does not consume the next character from ring or batch.

--- a/plans/perf/jsonmodem_flameview_profile_execplan.md
+++ b/plans/perf/jsonmodem_flameview_profile_execplan.md
@@ -1,0 +1,206 @@
+# Profile JsonModem Flavors with Flameview (CPU + Allocation-Focused)
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `PLANS.md` in the repository root for governing standards. This document is authored and maintained in accordance with those requirements.
+
+## Purpose / Big Picture
+
+This plan gives a reproducible workflow to profile all three JsonModem API flavors (`jsonmodem_events`, `jsonmodem_buffers`, `jsonmodem_values`) in release mode and inspect hotspots with flameview. After following it, a contributor can generate per-flavor CPU flamegraphs and allocation-focused flamegraphs, then open folded stacks in flameview to inspect heavy call paths interactively or via summaries.
+
+The user-visible outcome is concrete files you can open immediately: `*.cpu.folded`/`*.cpu.flamegraph.svg` for time-based hotspots and `*.alloc.focus.folded`/`*.alloc.focus.flamegraph.svg` for allocation-path hotspots.
+
+## Progress
+
+- [x] (2026-02-22 00:16Z) Confirmed the three target flavors and benchmark coverage (`jsonmodem_events`, `jsonmodem_buffers`, `jsonmodem_values`) in `crates/jsonmodem/benches/`.
+- [x] (2026-02-22 00:18Z) Validated tooling availability (`flameview`, `cargo-flamegraph`, `perf`, `inferno-collapse-perf`, `inferno-flamegraph`).
+- [x] (2026-02-22 00:20Z) Validated heavy benchmark target selection and filters; selected `streaming_json_large` with `/5000` filter for all three flavors.
+- [x] (2026-02-22 00:21Z) Generated release-mode CPU profiles for all three flavors using direct bench-binary perf recording.
+- [x] (2026-02-22 00:23Z) Generated allocation-focused folded stacks and flamegraphs by isolating allocator-including stack lines.
+- [x] (2026-02-22 00:24Z) Produced hotspot report and preserved profiling artifacts under `/tmp/jsonmodem_profiles_perf_direct_20260222_002044/`.
+- [x] (2026-02-22 00:25Z) Added self-serve flameview inspection instructions in this ExecPlan.
+
+## Surprises & Discoveries
+
+- Observation: Running `cargo flamegraph --bench ...` on this Criterion bench produced stacks dominated by Cargo activity rather than the benchmark process.
+  Evidence: flameview summaries showed `cargo::commands::metadata` and related frames at the top after `cargo flamegraph --package jsonmodem --bench streaming_json_large ...`.
+
+- Observation: Direct bench execution (`cargo bench --no-run` then run the produced bench binary with perf) yielded clean JsonModem hotspots.
+  Evidence: top exclusive symbols became parser/lexer functions such as `jsonmodem::parser::JsonModem<Ctx>::lex_state_step` and `jsonmodem::parser::scanner::Scanner::finish`.
+
+- Observation: Tracefs permissions in this environment block dynamic probes and trace events needed for direct allocation event profiling.
+  Evidence: `perf probe ...` failed with `No permission to write tracefs`; `perf record -e sdt_libc:...` failed with `No permissions to read /sys/kernel/tracing`.
+
+- Observation: Allocation-focused slicing from CPU stacks still provides actionable allocation-path hotspots (especially in buffers/values assembly paths).
+  Evidence: allocation-focused inclusive hotspots include `jsonmodem::backend::std::value_applicator::ValueApplicator::apply_string`, `jsonmodem::backend::std::value_zipper::ValueZipper::with_leaf_mut`, and `jsonmodem::jsonmodem_values::next_value_for_source`.
+
+## Decision Log
+
+- Decision: Profile `streaming_json_large` at filter `/5000` for each flavor instead of `single_chunk_json_large`.
+  Rationale: it is heavier and reduces harness/noise effects while keeping parity across all three flavors.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Use direct perf on the compiled bench binary (`--no-run`) instead of `cargo flamegraph` for these Criterion targets.
+  Rationale: this isolates benchmark execution and avoids Cargo process overhead dominating traces.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Use allocation-focused stack slicing as the default non-root allocation workflow.
+  Rationale: tracefs restrictions prevented allocator uprobe/trace-event recording in this environment; slicing alloc-related frames preserves useful optimization guidance without privileged setup.
+  Date/Author: 2026-02-22 / Codex.
+
+## Outcomes & Retrospective
+
+CPU and allocation-focused profiling for all three JsonModem flavors completed successfully in release mode, with artifacts saved and hotspot summaries generated. The workflow is stable and repeatable in an unprivileged shell. The main limitation is that direct allocator event profiling (malloc/free probe events) needs tracefs permissions; this plan includes a privileged optional path for environments where sudo access is available.
+
+The resulting hotspot patterns suggest parser lexing/scanning dominates all flavors, while buffers/values add noticeable allocation-heavy work in value assembly and container handling.
+
+## Context and Orientation
+
+This repository’s core parser crate is `crates/jsonmodem`. Benchmark binaries are Criterion benches in `crates/jsonmodem/benches/`. The three “flavors” are:
+
+- `jsonmodem_events`: core event stream parser path.
+- `jsonmodem_buffers`: event stream + buffer assembly path.
+- `jsonmodem_values`: value-producing adapter path.
+
+The selected benchmark binary target is `streaming_json_large` (from `crates/jsonmodem/benches/streaming_json_large.rs`) and each flavor is filtered at `/5000`.
+
+Profiling artifacts are written to one output directory (example: `/tmp/jsonmodem_profiles_perf_direct_20260222_002044/`) and include:
+
+- `*.cpu.perf.data`: raw perf capture.
+- `*.cpu.folded`: collapsed stacks for flameview.
+- `*.cpu.flamegraph.svg`: rendered CPU flamegraph.
+- `*.alloc.focus.folded`: allocation-focused collapsed stacks.
+- `*.alloc.focus.flamegraph.svg`: rendered allocation-focused flamegraph.
+- `hotspots_report.txt`: aggregated hotspots for CPU and allocation-focused views.
+
+## Plan of Work
+
+Build the `streaming_json_large` bench binary in release mode without running it, then run it directly under perf for each flavor filter. Convert perf output to folded stacks with `inferno-collapse-perf`, render SVG flamegraphs with `inferno-flamegraph`, and inspect both summaries and interactive views with flameview.
+
+For allocation-focused analysis in an unprivileged environment, derive a second folded file by keeping only stack lines that include allocator and reserve symbols (`__rust_alloc`, `__rdl_alloc`, `malloc`, `realloc`, `RawVec`, `reserve`, `alloc::alloc::`). This reveals where allocation-related cost concentrates.
+
+If tracefs permissions are available, optionally add direct allocator event profiling using libc probes/trace events.
+
+## Concrete Steps
+
+Run from repository root (`/home/friel/c/aaronfriel/jsonmodem-perf`).
+
+Build benchmark binary in release mode:
+
+    JSONMODEM_BENCH_FAST=1 cargo bench --package jsonmodem --bench streaming_json_large --no-run
+    BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_large-*' | head -n 1)
+    OUT_DIR=/tmp/jsonmodem_profiles_perf_direct_$(date +%Y%m%d_%H%M%S)
+    mkdir -p "$OUT_DIR"
+
+Collect CPU profiles for all three flavors:
+
+    for flavor in jsonmodem_events jsonmodem_buffers jsonmodem_values; do
+      perf record -F 400 --call-graph dwarf,64000 -o "$OUT_DIR/${flavor}.5000.cpu.perf.data" -- \
+        "$BIN" --bench "${flavor}/5000" --profile-time 5 >/dev/null 2>&1
+      perf script -i "$OUT_DIR/${flavor}.5000.cpu.perf.data" | inferno-collapse-perf > "$OUT_DIR/${flavor}.5000.cpu.folded"
+      inferno-flamegraph --title "${flavor}/5000 CPU" "$OUT_DIR/${flavor}.5000.cpu.folded" > "$OUT_DIR/${flavor}.5000.cpu.flamegraph.svg"
+    done
+
+Generate allocation-focused folded stacks and SVGs (non-root workflow):
+
+    ALLOC_RE='(__rust_alloc|__rdl_alloc|malloc|realloc|alloc::alloc::|RawVec|reserve|with_capacity)'
+    for flavor in jsonmodem_events jsonmodem_buffers jsonmodem_values; do
+      rg -N "$ALLOC_RE" "$OUT_DIR/${flavor}.5000.cpu.folded" > "$OUT_DIR/${flavor}.5000.alloc.focus.folded" || true
+      if [ -s "$OUT_DIR/${flavor}.5000.alloc.focus.folded" ]; then
+        inferno-flamegraph --title "${flavor}/5000 Allocation-Focused (CPU)" \
+          "$OUT_DIR/${flavor}.5000.alloc.focus.folded" > "$OUT_DIR/${flavor}.5000.alloc.focus.flamegraph.svg"
+      fi
+    done
+
+Preview summaries in terminal:
+
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_events.5000.cpu.folded"
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_buffers.5000.cpu.folded"
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_values.5000.cpu.folded"
+
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_events.5000.alloc.focus.folded"
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_buffers.5000.alloc.focus.folded"
+    flameview --summarize --max-lines 30 "$OUT_DIR/jsonmodem_values.5000.alloc.focus.folded"
+
+Open interactive flameview (your request):
+
+    flameview "$OUT_DIR/jsonmodem_events.5000.cpu.folded"
+    flameview "$OUT_DIR/jsonmodem_buffers.5000.cpu.folded"
+    flameview "$OUT_DIR/jsonmodem_values.5000.cpu.folded"
+
+    flameview "$OUT_DIR/jsonmodem_events.5000.alloc.focus.folded"
+    flameview "$OUT_DIR/jsonmodem_buffers.5000.alloc.focus.folded"
+    flameview "$OUT_DIR/jsonmodem_values.5000.alloc.focus.folded"
+
+Optional privileged allocator-event workflow (requires tracefs/sudo):
+
+    # Example only; run if your environment permits tracefs access.
+    sudo perf probe -x /lib/x86_64-linux-gnu/libc.so.6 'malloc size=%di'
+    sudo perf record -e probe_libc:malloc -g --call-graph dwarf,64000 -o "$OUT_DIR/malloc.perf.data" -- \
+      "$BIN" --bench jsonmodem_values/5000 --profile-time 5
+    sudo chown "$(id -u):$(id -g)" "$OUT_DIR/malloc.perf.data"
+    perf script -i "$OUT_DIR/malloc.perf.data" | inferno-collapse-perf > "$OUT_DIR/malloc.folded"
+    inferno-flamegraph --title "malloc call stacks" "$OUT_DIR/malloc.folded" > "$OUT_DIR/malloc.flamegraph.svg"
+    flameview "$OUT_DIR/malloc.folded"
+
+## Validation and Acceptance
+
+The workflow is accepted when all six folded files exist (three CPU and three allocation-focused) and flameview can open each one without errors. At minimum, verify:
+
+- `ls -1 "$OUT_DIR" | rg '\.cpu\.folded$'` returns three files.
+- `ls -1 "$OUT_DIR" | rg '\.alloc\.focus\.folded$'` returns three files.
+- `flameview --summarize "$OUT_DIR/jsonmodem_values.5000.cpu.folded"` prints a symbol summary.
+- `flameview --summarize "$OUT_DIR/jsonmodem_values.5000.alloc.focus.folded"` prints an allocation-focused symbol summary.
+
+Behavioral acceptance for hotspot quality:
+
+- CPU profiles show parser scanner/lexer hotspots (for example `JsonModem::lex_state_step`, `Scanner::consume_string_ascii_fast`, `Scanner::finish`).
+- Allocation-focused profiles show value/buffer assembly and container paths more prominently in buffers/values flavors.
+
+## Idempotence and Recovery
+
+All commands are idempotent when writing to a fresh `OUT_DIR`. Re-running in the same directory safely overwrites matching files.
+
+If perf capture is interrupted, rerun only the affected flavor command; conversion and rendering are independent per file. If symbol quality degrades, ensure release bench was built with debuginfo (`bench` profile already includes debuginfo in this repository’s current setup) and keep `--call-graph dwarf,64000`.
+
+If interactive flameview is unavailable in your terminal session, use `flameview --summarize` as a non-interactive fallback.
+
+## Artifacts and Notes
+
+Current run artifacts:
+
+    /tmp/jsonmodem_profiles_perf_direct_20260222_002044/
+      jsonmodem_events.5000.cpu.folded
+      jsonmodem_buffers.5000.cpu.folded
+      jsonmodem_values.5000.cpu.folded
+      jsonmodem_events.5000.alloc.focus.folded
+      jsonmodem_buffers.5000.alloc.focus.folded
+      jsonmodem_values.5000.alloc.focus.folded
+      hotspots_report.txt
+
+Example hotspot snippets from `hotspots_report.txt`:
+
+    CPU (events): jsonmodem::parser::JsonModem<Ctx>::lex_state_step
+    CPU (buffers): jsonmodem::parser::scanner::Scanner::consume_string_ascii_fast
+    CPU (values): jsonmodem::jsonmodem_values::next_value_for_source
+    Alloc-focus (buffers): jsonmodem::backend::std::value_applicator::ValueApplicator::apply_string
+    Alloc-focus (values): jsonmodem::backend::std::value_zipper::ValueZipper::with_leaf_mut
+
+## Interfaces and Dependencies
+
+Key CLI dependencies used by this plan:
+
+- `cargo` (bench build and target discovery).
+- `perf` (sampling and call graph capture).
+- `inferno-collapse-perf` (collapse perf script output to folded stacks).
+- `inferno-flamegraph` (render SVG from folded stacks).
+- `flameview` (interactive and summary inspection).
+- `rg` (allocation-focused stack filtering).
+
+Important benchmark interface:
+
+- Bench binary target: `streaming_json_large` (package `jsonmodem`).
+- Flavor filters: `jsonmodem_events/5000`, `jsonmodem_buffers/5000`, `jsonmodem_values/5000`.
+- Profiling mode: Criterion `--profile-time 5` for profiler-friendly steady execution.
+
+Change Note (2026-02-22): Created this ExecPlan and recorded the validated end-to-end workflow plus explicit flameview self-inspection instructions, because the user requested executable profiling instructions after workflow validation.

--- a/plans/perf/jsonmodem_hotspot_optimization_execplan.md
+++ b/plans/perf/jsonmodem_hotspot_optimization_execplan.md
@@ -1,0 +1,227 @@
+# Reduce JsonModem Hotspot Costs with Targeted Benchmarks and Verified Improvements
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Refer to `PLANS.md` in the repository root for governing standards. This document is authored and maintained in accordance with those requirements.
+
+## Purpose / Big Picture
+
+This plan turns hotspot profiling findings into measurable improvements. It adds focused benchmarks that isolate parser lex/scanner work, iterator finalization overhead, and values/buffers assembly work with less end-to-end harness noise. It also preserves baseline end-to-end timing for the existing medium and large streaming benchmarks so we can prove overall impact, not only microbench gains.
+
+After this plan, a contributor can:
+
+1. Run targeted benchmarks and collect baseline metrics for each hotspot area.
+2. Apply focused optimizations while maintaining parser correctness and adapter behavior.
+3. Re-run the same benchmark set and produce a before/after report covering each hotspot and overall medium/large parsing throughput.
+
+## Progress
+
+- [x] (2026-02-22 00:31Z) Confirmed hotspot areas and profiling evidence from prior flameview/perf run.
+- [x] (2026-02-22 00:34Z) Ran required `.agent/check.sh` baseline check; discovered pre-existing clippy failure in parser tests (`manual_flatten`), unrelated to this plan’s changes.
+- [x] (2026-02-22 00:36Z) Started this optimization ExecPlan and locked implementation scope.
+- [x] (2026-02-22 00:40Z) Added `hotspot_targets` benchmark and registered it in `crates/jsonmodem/Cargo.toml`.
+- [x] (2026-02-22 00:52Z) Implemented parser/scanner/drop-path and values/container assembly optimizations in planned files.
+- [x] (2026-02-22 01:08Z) Captured authoritative baseline vs optimized benchmark data with stabilized Criterion settings (`--measurement-time 5 --sample-size 50`) and archived outputs under `/tmp/jsonmodem_execplan_authoritative_20260222_stable/`.
+- [x] (2026-02-22 01:10Z) Refreshed post-change CPU and allocation-focused flameview artifacts for all three flavors at `/5000` under `/tmp/jsonmodem_profiles_perf_after_20260222_010934/`.
+- [x] (2026-02-22 01:12Z) Wrote before/after report with flameview self-serve workflow in `plans/perf/jsonmodem_hotspot_optimization_report.md`.
+- [x] (2026-02-22 01:13Z) Re-ran `.agent/check.sh`; build/tests pass and clippy still fails only on pre-existing parser test lint (`manual_flatten`).
+- [x] (2026-02-22 09:40Z) Completed deep-dive reprofiling of user-called hotspot frames (`consume_string_ascii_fast`, `push_ascii_to_scratch`, `push_key_from_str`, iterator drop/`finish`) and added findings to the report.
+
+## Surprises & Discoveries
+
+- Observation: CI-equivalent local check is not fully green before this effort due to a pre-existing clippy lint failure in parser tests.
+  Evidence: `.agent/check.sh` failed at `crates/jsonmodem/src/parser/tests.rs:1327` with `clippy::manual_flatten`.
+
+- Observation: In this environment, direct tracefs-based allocation probes are permission constrained, so non-root allocation analysis must rely on allocation-focused stack slicing from CPU profiles.
+  Evidence: `perf probe` and `perf record -e sdt_libc:*` permission errors in prior profiling run.
+
+- Observation: Benchmark noise was high when using `JSONMODEM_BENCH_FAST=1` (10 ms warmups), and sequential runs produced contradictory before/after outcomes.
+  Evidence: repeated captures in `/tmp/jsonmodem_hotspot_baseline_20260222_after*` contained large swings, including implausible reversals between runs.
+
+- Observation: Switching to longer Criterion sampling windows produced stable, plausible deltas aligned with profile-level behavior.
+  Evidence: authoritative dataset in `/tmp/jsonmodem_execplan_authoritative_20260222_stable/comparison.tsv` shows coherent medium/large and targeted trends.
+
+- Observation: In deep-dive runs, allocator cost remained concentrated under string scratch growth and iterator drop carryover work, and experimental mitigations were either regressive or inconclusive in this harness.
+  Evidence: `/tmp/jsonmodem_deep_dive_profile_20260222_093319/` plus deep-dive benchmark captures under `/tmp/jsonmodem_deep_dive_20260222_*`.
+
+## Decision Log
+
+- Decision: Create a new ExecPlan file instead of modifying `plans/perf/jsonmodem_flameview_profile_execplan.md`.
+  Rationale: the prior plan is operational profiling workflow documentation; this effort adds optimization implementation, targeted benchmarks, and comparative reporting.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Treat parser lex/scanner, iterator finalization, and values/buffers assembly as the three mandatory optimization buckets, with object-container handling folded into assembly optimizations.
+  Rationale: this aligns with measured hotspot concentration while keeping implementation scope tractable and verifiable in one engineering pass.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Produce authoritative before/after metrics from a clean detached baseline worktree plus benchmark harness only, then run identical commands on optimized code.
+  Rationale: this avoids relying on noisy prior runs and keeps baseline code truly pre-optimization while preserving identical benchmark entrypoints.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Use stable measurement settings (`--measurement-time 5 --sample-size 50`) for final reporting instead of fast mode.
+  Rationale: longer warmup/measurement cycles materially reduced variance and yielded reproducible directional conclusions.
+  Date/Author: 2026-02-22 / Codex.
+
+- Decision: Keep deep-dive experiments out of the committed implementation unless they show consistent wins across hotspot and e2e benches.
+  Rationale: interning and reserve-heuristic experiments were not consistently positive and risked regressions in object assembly and end-to-end cases.
+  Date/Author: 2026-02-22 / Codex.
+
+## Outcomes & Retrospective
+
+Implementation completed with measurable improvements in targeted hotspots and `streaming_json_medium`, with mixed outcomes on `streaming_json_large` by flavor. Detailed numbers and reproducible commands are in `plans/perf/jsonmodem_hotspot_optimization_report.md`.
+
+Headline outcomes from the authoritative dataset (`/tmp/jsonmodem_execplan_authoritative_20260222_stable/comparison.tsv`):
+
+- Targeted hotspot aggregate: `-2.289%` over 5 cases.
+- `streaming_json_medium` aggregate: `-3.028%` over 9 cases.
+- `streaming_json_large` aggregate: `-0.228%` over 9 cases (near-flat overall).
+
+By flavor on `streaming_json_large`:
+
+- `jsonmodem_buffers`: improved (`-2.512%` aggregate).
+- `jsonmodem_events`: essentially flat (`+0.122%` aggregate).
+- `jsonmodem_values`: slight regression (`+1.705%` aggregate), still within a tight band but directionally behind medium gains.
+
+Safety/conformance status:
+
+- `.agent/check.sh` confirms formatting/build/tests pass.
+- clippy remains red only on pre-existing `crates/jsonmodem/src/parser/tests.rs:1327` (`clippy::manual_flatten`), not introduced by this plan.
+
+Retrospective:
+
+- The added targeted bench gave actionable isolation for parser/drop/assembly improvements.
+- The biggest remaining optimization opportunity is values-path large payload behavior (`next_value_for_source` plus value applicator/zipper allocation-heavy paths), corroborated by post-change flameview captures.
+- Additional deep-dive profiling confirms user-highlighted frames are still allocation-heavy and should be addressed with focused structural changes (scratch/carryover storage strategy, property-name path handling), not ad-hoc reserve tweaks.
+
+## Context and Orientation
+
+The hotspot evidence comes from perf/flameview captures over `streaming_json_large/*/5000` and points to:
+
+- Parser lex/scanner core:
+  - `crates/jsonmodem/src/parser/mod.rs` (`next_event_with`, `lex_state_step`, `dispatch_parse_state`)
+  - `crates/jsonmodem/src/parser/scanner/mod.rs` (`consume_string_ascii_fast`, `finish`)
+- Iterator finalization/drop path:
+  - `crates/jsonmodem/src/parser/mod.rs` (`Drop for JsonModemIterator` and `JsonModemClosed`)
+- Values/buffers assembly:
+  - `crates/jsonmodem/src/jsonmodem_values.rs`
+  - `crates/jsonmodem/src/jsonmodem_buffers.rs`
+  - `crates/jsonmodem/src/backend/std/value_applicator.rs`
+  - `crates/jsonmodem/src/backend/std/value_zipper.rs`
+
+Existing end-to-end benchmark binaries already live in `crates/jsonmodem/benches/`, especially `streaming_json_medium.rs` and `streaming_json_large.rs`.
+
+## Plan of Work
+
+First, add a new targeted Criterion benchmark binary under `crates/jsonmodem/benches/` that provides low-noise measurements for:
+
+- parser string-lex/scanner-heavy workload using the events adapter;
+- iterator/feed finalization overhead with tiny chunks and repeated feed/drop cycles;
+- buffer/value assembly-heavy workload using object/string-rich payloads.
+
+The benchmark should keep setup outside the inner iteration and avoid unrelated conversion work where possible.
+
+Second, record baseline timings for:
+
+- all targeted benchmark functions;
+- existing end-to-end `streaming_json_medium` and `streaming_json_large` jsonmodem flavor cases.
+
+Third, implement low-risk optimizations mapped to each hotspot bucket. Initial optimization candidates:
+
+- scanner/parser path: reduce overhead in string fast-path scanning and session finalization fast paths;
+- iterator finalization: reduce unnecessary work when no carryover needs to be persisted;
+- assembly path: reduce redundant work in values classification and container initialization/mutation paths.
+
+Fourth, re-run the exact same benchmark commands and compare before/after numbers. Produce a report in `plans/perf/` summarizing area-level and end-to-end changes with commands and outputs.
+
+Finally, run project checks to validate conformance and document any pre-existing failures separately from newly introduced regressions.
+
+## Concrete Steps
+
+Run from repository root (`/home/friel/c/aaronfriel/jsonmodem-perf`).
+
+1. Add targeted benchmark source and register `[[bench]]` entry.
+
+2. Collect baseline benchmark data:
+
+    # Baseline from clean detached worktree at pre-change HEAD:
+    cargo bench --package jsonmodem --bench hotspot_targets -- --measurement-time 5 --sample-size 50
+    cargo bench --package jsonmodem --bench streaming_json_medium -- --measurement-time 5 --sample-size 50
+    cargo bench --package jsonmodem --bench streaming_json_large -- --measurement-time 5 --sample-size 50
+
+3. Apply hotspot-focused optimizations in parser/scanner and values/buffers code paths.
+
+4. Re-run the same three commands and capture after metrics.
+
+5. Optionally refresh CPU and allocation-focused folded stacks for the targeted benchmark cases:
+
+    cargo bench --package jsonmodem --bench streaming_json_large --no-run
+    BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_large-*' | head -n 1)
+    perf record -F 400 --call-graph dwarf,64000 -o /tmp/profile.perf.data -- "$BIN" --bench jsonmodem_values/5000 --profile-time 5
+    perf script -i /tmp/profile.perf.data | inferno-collapse-perf > /tmp/profile.folded
+    flameview --summarize --max-lines 60 /tmp/profile.folded
+    flameview /tmp/profile.folded
+
+6. Write comparison report under `plans/perf/` with before/after numbers and interpretation.
+
+7. Run checks:
+
+    .agent/check.sh
+
+## Validation and Acceptance
+
+Acceptance requires all of the following:
+
+- Targeted benchmark binary exists and runs successfully in release bench mode.
+- Before and after timing data exists for each hotspot-targeted benchmark function.
+- Before and after timing data exists for both end-to-end benchmarks (`streaming_json_medium`, `streaming_json_large`) for jsonmodem events/buffers/values cases.
+- No correctness regressions in parser/buffers/values tests attributable to this work.
+- Final report clearly states improvements or regressions per area and overall.
+
+## Idempotence and Recovery
+
+Benchmark commands are repeatable and safe; use `JSONMODEM_BENCH_FAST=1` for quicker cycles. If a specific optimization regresses correctness or performance, revert that change independently and re-run only the affected benchmark and test subset before full checks.
+
+Because `.agent/check.sh` currently fails on a pre-existing clippy lint in tests, this plan records that failure explicitly and treats new regressions separately.
+
+## Artifacts and Notes
+
+Artifacts produced by this plan:
+
+- New targeted benchmark source in `crates/jsonmodem/benches/`.
+- Updated `crates/jsonmodem/Cargo.toml` bench registration.
+- Before/after metrics report in `plans/perf/jsonmodem_hotspot_optimization_report.md`.
+- Authoritative benchmark captures and parsed comparisons:
+  - `/tmp/jsonmodem_execplan_authoritative_20260222_stable/baseline/`
+  - `/tmp/jsonmodem_execplan_authoritative_20260222_stable/after/`
+  - `/tmp/jsonmodem_execplan_authoritative_20260222_stable/comparison.tsv`
+- Post-change perf/flameview artifacts:
+  - `/tmp/jsonmodem_profiles_perf_after_20260222_010934/`
+- Deep-dive hotspot artifacts:
+  - `/tmp/jsonmodem_deep_dive_profile_20260222_093319/`
+  - `/tmp/jsonmodem_deep_dive_20260222_015100/`
+  - `/tmp/jsonmodem_deep_dive_20260222_015100_repeat/`
+  - `/tmp/jsonmodem_deep_dive_20260222_015100_revert_finish_fastpath/`
+  - `/tmp/jsonmodem_deep_dive_20260222_015100_revert_all_experiments/`
+
+## Interfaces and Dependencies
+
+Benchmark interfaces:
+
+- Existing: `streaming_json_medium`, `streaming_json_large`.
+- New: `hotspot_targets` (to be added by this plan).
+
+Primary dependencies:
+
+- `criterion` for timing measurements.
+- `perf`, `inferno-collapse-perf`, `inferno-flamegraph`, `flameview` for hotspot verification when needed.
+
+Code interfaces likely touched:
+
+- `crate::parser::scanner::Scanner`
+- `crate::parser::JsonModemIterator` / `JsonModemClosed` drop/finalization paths
+- `crate::jsonmodem_values` emit/classification helpers
+- `crate::backend::std::value_applicator` and possibly `value_zipper` container/value mutation paths
+
+Change Note (2026-02-22): Created this ExecPlan to convert hotspot findings into targeted benchmark coverage, measurable optimizations, and a before/after performance report as requested by the user.
+Change Note (2026-02-22): Updated this ExecPlan to reflect completed implementation, stabilized authoritative benchmark methodology, final before/after outcomes, artifact locations, and flameview self-inspection workflow.
+Change Note (2026-02-22): Added deep-dive hotspot profiling outcomes and documented that exploratory mitigations were measured but not retained due inconsistent performance impact.

--- a/plans/perf/jsonmodem_hotspot_optimization_report.md
+++ b/plans/perf/jsonmodem_hotspot_optimization_report.md
@@ -1,0 +1,228 @@
+# JsonModem Hotspot Optimization Report (2026-02-22)
+
+## Scope
+
+This report covers:
+
+- New targeted benchmark coverage for parser/scanner, iterator drop/finalization, and values/buffers assembly paths.
+- Baseline vs optimized timing in release bench mode.
+- End-to-end timing for `streaming_json_medium` and `streaming_json_large` across all three JsonModem flavors.
+- Post-change CPU and allocation-focused hotspot inspection with `perf` + `flameview`.
+
+## Code Changes In Scope
+
+- Added targeted bench binary: `crates/jsonmodem/benches/hotspot_targets.rs`.
+- Registered bench target in `crates/jsonmodem/Cargo.toml` (`[[bench]] name = "hotspot_targets"`).
+- Parser/scanner/drop path changes:
+  - `crates/jsonmodem/src/parser/scanner/mod.rs`
+  - `crates/jsonmodem/src/parser/mod.rs`
+- Values/container assembly changes:
+  - `crates/jsonmodem/src/jsonmodem_values.rs`
+  - `crates/jsonmodem/src/backend/std/value_applicator.rs`
+
+## Measurement Method
+
+To reduce prior noise from fast-mode warmups, the authoritative run used:
+
+- Release benches (`cargo bench`, optimized profile).
+- `--measurement-time 5 --sample-size 50`.
+- A clean baseline worktree at pre-change `HEAD` plus benchmark harness only.
+
+Authoritative artifacts:
+
+- Baseline: `/tmp/jsonmodem_execplan_authoritative_20260222_stable/baseline/`
+- Optimized: `/tmp/jsonmodem_execplan_authoritative_20260222_stable/after/`
+- Parsed comparison TSV: `/tmp/jsonmodem_execplan_authoritative_20260222_stable/comparison.tsv`
+
+Commands used:
+
+    cargo bench --package jsonmodem --bench hotspot_targets -- --measurement-time 5 --sample-size 50
+    cargo bench --package jsonmodem --bench streaming_json_medium -- --measurement-time 5 --sample-size 50
+    cargo bench --package jsonmodem --bench streaming_json_large -- --measurement-time 5 --sample-size 50
+
+## Targeted Benchmarks (Hotspots)
+
+Negative delta means faster (improved).
+
+| Benchmark | Baseline | Optimized | Delta |
+| --- | ---: | ---: | ---: |
+| `hotspot_targets/parser_events_ascii_single_chunk_256k` | 62.280 us | 63.400 us | +1.798% |
+| `hotspot_targets/parser_events_ascii_cross_chunk_256k_1024` | 164.51 us | 157.23 us | -4.425% |
+| `hotspot_targets/iterator_drop_small_value_cycles/4096` | 465.83 us | 436.43 us | -6.311% |
+| `hotspot_targets/buffers_object_assembly_1024x48` | 461.22 us | 453.23 us | -1.732% |
+| `hotspot_targets/values_object_assembly_1024x48` | 467.96 us | 464.33 us | -0.776% |
+
+Aggregate targeted delta across all 5 cases: **-2.289%**.
+
+## End-to-End: streaming_json_medium
+
+| Benchmark | Baseline | Optimized | Delta |
+| --- | ---: | ---: | ---: |
+| `streaming_json_medium/jsonmodem_events/100` | 28.559 us | 29.386 us | +2.896% |
+| `streaming_json_medium/jsonmodem_events/1000` | 59.302 us | 59.304 us | +0.003% |
+| `streaming_json_medium/jsonmodem_events/5000` | 126.95 us | 120.78 us | -4.860% |
+| `streaming_json_medium/jsonmodem_buffers/100` | 39.877 us | 38.088 us | -4.486% |
+| `streaming_json_medium/jsonmodem_buffers/1000` | 81.009 us | 77.720 us | -4.060% |
+| `streaming_json_medium/jsonmodem_buffers/5000` | 159.16 us | 153.83 us | -3.349% |
+| `streaming_json_medium/jsonmodem_values/100` | 40.239 us | 38.596 us | -4.083% |
+| `streaming_json_medium/jsonmodem_values/1000` | 84.084 us | 81.200 us | -3.430% |
+| `streaming_json_medium/jsonmodem_values/5000` | 171.99 us | 161.87 us | -5.884% |
+
+Aggregate medium delta across all 9 cases: **-3.028%**.
+
+## End-to-End: streaming_json_large
+
+| Benchmark | Baseline | Optimized | Delta |
+| --- | ---: | ---: | ---: |
+| `streaming_json_large/jsonmodem_events/100` | 54.765 us | 53.377 us | -2.534% |
+| `streaming_json_large/jsonmodem_events/1000` | 95.603 us | 97.696 us | +2.189% |
+| `streaming_json_large/jsonmodem_events/5000` | 230.26 us | 231.90 us | +0.712% |
+| `streaming_json_large/jsonmodem_buffers/100` | 65.708 us | 65.289 us | -0.638% |
+| `streaming_json_large/jsonmodem_buffers/1000` | 111.59 us | 107.99 us | -3.226% |
+| `streaming_json_large/jsonmodem_buffers/5000` | 259.28 us | 249.76 us | -3.672% |
+| `streaming_json_large/jsonmodem_values/100` | 66.800 us | 67.561 us | +1.139% |
+| `streaming_json_large/jsonmodem_values/1000` | 115.81 us | 118.52 us | +2.340% |
+| `streaming_json_large/jsonmodem_values/5000` | 271.18 us | 275.62 us | +1.637% |
+
+Aggregate large delta across all 9 cases: **-0.228%**.
+
+Flavor-level aggregate deltas on `streaming_json_large`:
+
+- events: **+0.122%** (flat/slight regression)
+- buffers: **-2.512%** (improved)
+- values: **+1.705%** (slight regression)
+
+## Post-Change Hotspots (CPU + Allocation-Focused)
+
+Profile artifacts:
+
+- `/tmp/jsonmodem_profiles_perf_after_20260222_010934/`
+
+Generated files include per-flavor:
+
+- `*.5000.cpu.folded`
+- `*.5000.cpu.flamegraph.svg`
+- `*.5000.alloc.focus.folded`
+- `*.5000.alloc.focus.flamegraph.svg`
+- `*.5000.cpu.summary.txt`
+- `*.5000.alloc.summary.txt`
+
+Top inclusive CPU hotspots (post-change):
+
+- Events flavor: parser loop dominates (`JsonModem::next_event_with`, `next_event_step`, `lex`, `lex_state_step`), with `Scanner::consume_string_ascii_fast` still material.
+- Buffers flavor: parser loop still dominates plus assembly path (`ValueApplicator::push`, `ValueZipper::with_leaf_mut`).
+- Values flavor: `jsonmodem_values::next_value_for_source`/`next_emit_kind` on top of parser and buffers adapter layers.
+
+Top allocation-focused hotspots (post-change):
+
+- `jsonmodem::backend::std::value_applicator::ValueApplicator::apply_string`
+- `jsonmodem::backend::std::value_zipper::ValueZipper::with_leaf_mut`
+- `jsonmodem::parser::scanner::Scanner::push_ascii_to_scratch`
+- drop/finalization paths involving `JsonModemIterator` and `ScannerState`
+
+## Clear Next Optimization Targets
+
+Based on the latest profiles and deltas, the clearest remaining targets are:
+
+1. Parser single-chunk fast path (`Scanner::consume_string_ascii_fast` and nearby lex dispatch), since targeted single-chunk parser benchmark regressed while cross-chunk improved.
+2. Values flavor on large payloads (`jsonmodem_values::next_value_for_source` + container/path mutation) where `streaming_json_large/jsonmodem_values/*` is still mildly slower.
+3. Allocation pressure in string/container assembly (`ValueApplicator::apply_string`, `ValueZipper::with_leaf_mut`) and scratch growth (`push_ascii_to_scratch`) visible in allocation-focused stacks.
+
+## Deep Dive: Requested Hotspot Paths (2026-02-22)
+
+User-requested focus paths were re-profiled directly with `perf` + collapsed stacks:
+
+- Artifacts: `/tmp/jsonmodem_deep_dive_profile_20260222_093319/`
+- Sample collection warning: one perf chunk lost (`Processed 2772 events and lost 1 chunks`), but hotspot ordering remained stable.
+
+Inclusive CPU percentages for requested symbols (at `streaming_json_large/*/5000`):
+
+- `jsonmodem_events`:
+  - `Scanner::consume_string_ascii_fast`: `25.34%`
+  - `Scanner::push_ascii_to_scratch`: `8.29%`
+  - `StdBackend::push_key_from_str`: `0.43%`
+  - `JsonModemIterator::drop`: `17.39%`
+  - `Scanner::finish`: `4.89%`
+- `jsonmodem_buffers`:
+  - `Scanner::consume_string_ascii_fast`: `23.52%`
+  - `Scanner::push_ascii_to_scratch`: `7.77%`
+  - `StdBackend::push_key_from_str`: `0.47%`
+  - `JsonModemIterator::drop`: `16.08%`
+  - `Scanner::finish`: `3.51%`
+- `jsonmodem_values`:
+  - `Scanner::consume_string_ascii_fast`: `21.89%`
+  - `Scanner::push_ascii_to_scratch`: `7.92%`
+  - `StdBackend::push_key_from_str`: `0.76%`
+  - `JsonModemIterator::drop`: `13.53%`
+  - `Scanner::finish`: `3.77%`
+
+Allocation-focused percentages for the same symbols:
+
+- `jsonmodem_events`: `consume_string_ascii_fast/push_ascii_to_scratch` each `51.44%`, `push_key_from_str` `6.09%`, `drop` `18.18%`, `finish` `9.07%`.
+- `jsonmodem_buffers`: `consume_string_ascii_fast/push_ascii_to_scratch` each `30.32%`, `push_key_from_str` `5.44%`, `drop` `14.56%`, `finish` `3.23%`.
+- `jsonmodem_values`: `consume_string_ascii_fast/push_ascii_to_scratch` each `14.66%`, `push_key_from_str` `13.17%`, `drop` `16.16%`, `finish` `10.28%`.
+
+Line-level call-tree evidence (`perf report -F+srcline --stdio`) showed allocator time concentrated in:
+
+- `String::reserve`/`RawVec::reserve` under `Scanner::push_ascii_to_scratch`.
+- `Vec::reserve`/`RawVec::reserve` in path growth work under `StdBackend::push_key_from_str`.
+- `VecDeque` growth work under `Scanner::finish` from iterator drop carryover writes.
+
+Experiment notes during this deep dive:
+
+- Tried key interning in `StdBackend::push_key_from_str`: reduced allocations in principle but regressed object assembly benches in this harness, so not kept.
+- Tried broader `finish` no-op fast path and aggressive reserve heuristics: mixed/noisy and not consistently positive, so not kept.
+
+## How To Inspect Flamegraphs Yourself With flameview
+
+From repo root:
+
+    cargo bench --package jsonmodem --bench streaming_json_large --no-run
+    BIN=$(find target/release/deps -maxdepth 1 -executable -name 'streaming_json_large-*' | head -n 1)
+    OUT=/tmp/jsonmodem_profiles_manual_$(date +%Y%m%d_%H%M%S)
+    mkdir -p "$OUT"
+
+Record CPU profile for each flavor (release benchmark binary):
+
+    for flavor in jsonmodem_events jsonmodem_buffers jsonmodem_values; do
+      perf record -F 400 --call-graph dwarf,64000 -o "$OUT/${flavor}.5000.cpu.perf.data" -- \
+        "$BIN" --bench "${flavor}/5000" --profile-time 5 >/dev/null 2>&1
+      perf script -i "$OUT/${flavor}.5000.cpu.perf.data" | inferno-collapse-perf > "$OUT/${flavor}.5000.cpu.folded"
+      inferno-flamegraph --title "${flavor}/5000 CPU" "$OUT/${flavor}.5000.cpu.folded" > "$OUT/${flavor}.5000.cpu.flamegraph.svg"
+    done
+
+Optional allocation-focused view by slicing allocation-related stacks from CPU data:
+
+    ALLOC_RE='(__rust_alloc|__rdl_alloc|malloc|realloc|alloc::alloc::|RawVec|reserve|with_capacity)'
+    for flavor in jsonmodem_events jsonmodem_buffers jsonmodem_values; do
+      rg -N "$ALLOC_RE" "$OUT/${flavor}.5000.cpu.folded" > "$OUT/${flavor}.5000.alloc.focus.folded" || true
+      if [ -s "$OUT/${flavor}.5000.alloc.focus.folded" ]; then
+        inferno-flamegraph --title "${flavor}/5000 Allocation-Focused (CPU)" \
+          "$OUT/${flavor}.5000.alloc.focus.folded" > "$OUT/${flavor}.5000.alloc.focus.flamegraph.svg"
+      fi
+    done
+
+Inspect summaries:
+
+    flameview --summarize --max-lines 60 "$OUT/jsonmodem_events.5000.cpu.folded"
+    flameview --summarize --max-lines 60 "$OUT/jsonmodem_buffers.5000.cpu.folded"
+    flameview --summarize --max-lines 60 "$OUT/jsonmodem_values.5000.cpu.folded"
+
+Open interactive flameview session:
+
+    flameview "$OUT/jsonmodem_events.5000.cpu.folded"
+    flameview "$OUT/jsonmodem_buffers.5000.cpu.folded"
+    flameview "$OUT/jsonmodem_values.5000.cpu.folded"
+
+    flameview "$OUT/jsonmodem_events.5000.alloc.focus.folded"
+    flameview "$OUT/jsonmodem_buffers.5000.alloc.focus.folded"
+    flameview "$OUT/jsonmodem_values.5000.alloc.focus.folded"
+
+## Conformance / Safety Validation
+
+` .agent/check.sh ` run after changes:
+
+- `rustfmt` passed.
+- build passed.
+- tests passed.
+- clippy failed due pre-existing unrelated lint in `crates/jsonmodem/src/parser/tests.rs:1327` (`clippy::manual_flatten`).


### PR DESCRIPTION
## Summary

This PR adds targeted performance benchmarking and profiling documentation for jsonmodem, then applies focused parser/assembly optimizations and records before/after outcomes.

### What changed

- Added a new targeted Criterion bench:
  - `crates/jsonmodem/benches/hotspot_targets.rs`
  - registered in `crates/jsonmodem/Cargo.toml`
- Optimized parser/scanner drop/finalization carryover path:
  - `crates/jsonmodem/src/parser/mod.rs`
  - `crates/jsonmodem/src/parser/scanner/mod.rs`
- Optimized values/container assembly paths:
  - `crates/jsonmodem/src/jsonmodem_values.rs`
  - `crates/jsonmodem/src/backend/std/value_applicator.rs`
- Added ExecPlan and report docs:
  - `plans/perf/jsonmodem_flameview_profile_execplan.md`
  - `plans/perf/jsonmodem_hotspot_optimization_execplan.md`
  - `plans/perf/jsonmodem_hotspot_optimization_report.md`

## Performance / profiling artifacts

- Authoritative baseline vs optimized bench captures:
  - `/tmp/jsonmodem_execplan_authoritative_20260222_stable/`
- Deep-dive hotspot profiling captures:
  - `/tmp/jsonmodem_deep_dive_profile_20260222_093319/`

## Validation

- Ran `.agent/check.sh`
  - `rustfmt`: pass
  - build: pass
  - tests: pass
  - clippy: fails on pre-existing lint in `crates/jsonmodem/src/parser/tests.rs:1327` (`clippy::manual_flatten`)

## Notes

The report includes copy/paste instructions for reproducing CPU and allocation-focused flameview inspection across all three flavors.
