### PR TITLE
[jsonmodem] Fix Python buffer ownership and expand memory-safety testing

### DIFF
--- a/.agent/check-miri.sh
+++ b/.agent/check-miri.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+TOOLCHAIN="${JSONMODEM_MEMORY_TOOLCHAIN:-nightly}"
+CASES="${JSONMODEM_SAFETY_CASES:-32}"
+MODE="${1:-all}"
+if [[ "$MODE" != all && "$MODE" != targeted ]]; then
+    echo "Usage: $0 [all|targeted]" >&2
+    exit 1
+fi
+if [[ ! "$CASES" =~ ^[1-9][0-9]*$ ]]; then
+    echo "JSONMODEM_SAFETY_CASES must be a positive integer" >&2
+    exit 1
+fi
+rustc "+$TOOLCHAIN" -vV
+cargo "+$TOOLCHAIN" miri setup
+if [[ "$MODE" == all ]]; then
+    MIRIFLAGS="-Zmiri-env-set=JSONMODEM_SAFETY_CASES=$CASES" \
+        cargo "+$TOOLCHAIN" miri nextest run --workspace --profile default-miri \
+        --exclude jsonmodem-fuzz --exclude jsonmodem-py
+fi
+for model in stacked tree; do
+    for seed in 0 1 2; do
+        export MIRIFLAGS="-Zmiri-seed=$seed -Zmiri-env-set=JSONMODEM_SAFETY_CASES=$CASES"
+        if [[ "$model" == tree ]]; then
+            MIRIFLAGS+=" -Zmiri-tree-borrows"
+        fi
+        echo "Miri model=$model execution_seed=$seed generated_cases=$CASES"
+        cargo "+$TOOLCHAIN" miri test -p jsonmodem --lib memory_safety -- --nocapture
+        cargo "+$TOOLCHAIN" miri test -p jsonmodem --test memory_safety -- --nocapture
+    done
+done

--- a/.agent/check-py-memory.sh
+++ b/.agent/check-py-memory.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+if [[ "$(uname -s)" != Linux || "$(uname -m)" != x86_64 ]]; then
+    echo "This check requires Linux x86_64." >&2
+    exit 1
+fi
+
+TOOLCHAIN="${JSONMODEM_MEMORY_TOOLCHAIN:-nightly}"
+BUILD="$ROOT/target/python-memory"
+VENV="$BUILD/venv"
+mkdir -p "$BUILD/wheels"
+uv venv --allow-existing --python "${JSONMODEM_MEMORY_PYTHON:-python3}" "$VENV"
+uv pip install --python "$VENV/bin/python" maturin pytest
+
+rustc "+$TOOLCHAIN" -vV
+"$VENV/bin/python" -VV
+LIBDIR="$("$VENV/bin/python" -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+LIBRARY="$("$VENV/bin/python" -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY").removeprefix("lib").split(".so")[0])')"
+
+# A Rust executable supplies exactly the runtime used to instrument the extension.
+rustc "+$TOOLCHAIN" --edition=2024 -Zsanitizer=address -Cdebuginfo=1 \
+    -L "native=$LIBDIR" -l "$LIBRARY" \
+    -C "link-arg=-Wl,-rpath,$LIBDIR" -C link-arg=-Wl,--export-dynamic \
+    scripts/python_memory_runner.rs -o "$BUILD/python-memory"
+rustc "+$TOOLCHAIN" --edition=2024 -Zsanitizer=address -Cdebuginfo=1 --crate-type cdylib \
+    scripts/asan_failure.rs -o "$BUILD/asan_failure.so"
+
+export PYTHONMALLOC=malloc
+# CPython itself is uninstrumented and retains allocations at shutdown. This
+# checks invalid accesses, not interpreter-wide leaks; buffer release has tests.
+export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1
+ulimit -c 0
+"$VENV/bin/python" scripts/check_asan_failure.py \
+    "$BUILD/python-memory" "$VENV/bin/python" "$BUILD/asan_failure.so" "$BUILD/asan-failure.log"
+
+RUSTUP_TOOLCHAIN="$TOOLCHAIN" CARGO_TARGET_DIR="$BUILD/cargo" \
+    RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=1" \
+    "$VENV/bin/maturin" build -m crates/jsonmodem-py/Cargo.toml \
+    --interpreter "$VENV/bin/python" \
+    --release --target x86_64-unknown-linux-gnu --out "$BUILD/wheels"
+uv pip install --python "$VENV/bin/python" --reinstall "$BUILD"/wheels/jsonmodem-*.whl
+EXTENSION="$("$BUILD/python-memory" "$VENV/bin/python" -c \
+    'import jsonmodem._jsonmodem as extension; print(extension.__file__)')"
+if [[ "$EXTENSION" != "$VENV/"* ]]; then
+    echo "Expected the instrumented wheel in $VENV, got $EXTENSION" >&2
+    exit 1
+fi
+echo "Instrumented extension: $EXTENSION"
+nm -D "$EXTENSION" | grep __asan_init
+"$BUILD/python-memory" "$VENV/bin/python" -m pytest -q crates/jsonmodem-py/tests

--- a/.agent/check-py-memory.sh
+++ b/.agent/check-py-memory.sh
@@ -50,4 +50,5 @@ if [[ "$EXTENSION" != "$VENV/"* ]]; then
 fi
 echo "Instrumented extension: $EXTENSION"
 nm -D "$EXTENSION" | grep __asan_init
+export JSONMODEM_MEMORY_RUNNER="$BUILD/python-memory"
 "$BUILD/python-memory" "$VENV/bin/python" -m pytest -q crates/jsonmodem-py/tests

--- a/.agent/check.sh
+++ b/.agent/check.sh
@@ -55,7 +55,7 @@ run_step "clippy (cfg=miri)" \
 # 3. Optional Miri (cfg via env var)
 ###############################################################################
 if [[ "${AGENT_CHECK_MIRI_DISABLE:-true}" != "true" ]]; then
-  run_step "miri test"      env JSONMODEM_TEST_FAST=1 JSONMODEM_BENCH_FAST=1 cargo +nightly miri test --workspace
+  run_step "miri tests" bash "$REPO_ROOT/.agent/check-miri.sh"
 else
   echo "⚠️  AGENT_CHECK_MIRI_DISABLE=true – skipping Miri checks."
 fi

--- a/.agent/setup.sh
+++ b/.agent/setup.sh
@@ -56,7 +56,7 @@ fi
 # LLVM/Clang + perf tooling
 ################################################################################
 sudo apt-get update
-sudo apt-get install -y wget gnupg lsb-release
+sudo apt-get install -y wget gnupg lsb-release binutils build-essential
 wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /usr/share/keyrings/llvm.asc
 echo "deb [signed-by=/usr/share/keyrings/llvm.asc] \
   http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${CLANG_VERSION} main" | \

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   miri:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +23,5 @@ jobs:
         with:
           tool: nextest
 
-      - name: Run tests under Miri (nextest)
-        run: |
-          cargo +nightly miri setup
-          cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+      - name: Run full suite and targeted memory-safety tests
+        run: bash .agent/check-miri.sh

--- a/.github/workflows/python-memory.yml
+++ b/.github/workflows/python-memory.yml
@@ -1,0 +1,28 @@
+name: Python memory safety
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  address-sanitizer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: astral-sh/setup-uv@v6
+      - name: Verify instrumentation and test Python extension
+        run: bash .agent/check-py-memory.sh
+      - name: Save instrumentation failure check
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: address-sanitizer-activation
+          path: target/python-memory/asan-failure.log

--- a/.github/workflows/python-memory.yml
+++ b/.github/workflows/python-memory.yml
@@ -9,6 +9,11 @@ jobs:
   address-sanitizer:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        python: ['3.9', '3.13']
+    env:
+      JSONMODEM_MEMORY_PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -16,7 +21,7 @@ jobs:
           toolchain: nightly
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python }}
       - uses: astral-sh/setup-uv@v6
       - name: Verify instrumentation and test Python extension
         run: bash .agent/check-py-memory.sh
@@ -24,5 +29,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: address-sanitizer-activation
+          name: address-sanitizer-activation-${{ matrix.python }}
           path: target/python-memory/asan-failure.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,16 @@ terminal.
 
 ## Python bindings
 
+Memory-safety checks are separate from the ordinary test scripts. Run
+`bash .agent/check-miri.sh` for the Rust suite and targeted tests under both Miri
+reference models. Run `bash .agent/check-py-memory.sh` for the Python extension
+under AddressSanitizer. The latter requires Linux x86_64, a Rust nightly
+toolchain, `uv`, `nm` (binutils), a C linker, and a Python interpreter with a
+shared `libpython`. It creates its own environment under `target/python-memory`.
+The existing setup scripts install the Rust and Python development tools;
+`.agent/setup.sh` installs binutils and the linker. See
+`docs/memory-safety-testing.md` for coverage and limitations.
+
 Building and testing the Python bindings is driven by two helper scripts,
 `setup-py.sh` and `check-py.sh`.  `setup-py.sh` installs
 [uv](https://github.com/astral-sh/uv), creates a `.venv` in the repository root,

--- a/crates/jsonmodem-py/README.md
+++ b/crates/jsonmodem-py/README.md
@@ -24,8 +24,9 @@ payloads are lightweight `StringPayload` objects with `.fragment`,
 `feed()` accepts one `str`, `bytes`, `bytearray`, or contiguous `memoryview`
 chunk, or an iterable of those chunk types. Passing an iterable is the preferred
 way to process many small HTTP or LLM fragments because it uses one Python/Rust
-call while preserving event order. Bytes-like chunks are read through Python's
-buffer protocol for the duration of the call.
+call while preserving event order. Immutable bytes-backed input can be borrowed.
+Mutable buffers and exporters whose storage cannot be verified as immutable are
+copied before parsing, so Python callbacks cannot change text being parsed.
 
 Use constructor options to shape the event stream without switching classes:
 
@@ -42,6 +43,12 @@ object key or array index, for example `"items.*.metadata.etag"`. With
 `memoryview` chunks, or an iterable of those chunks. Unescaped string fragments
 that point into the current input are returned as `memoryview` objects; escaped
 fragments fall back to `str`.
+
+Direct memoryview inputs in this mode must be backed by `bytes`. Other accepted
+read-only exporters are snapshotted into immutable bytes; their payload views
+retain the snapshot rather than the original exporter. Parsing and payloads use
+the same acquired storage even if an exporter returns different buffers on
+successive requests.
 
 ```python
 from jsonmodem import JsonModem, ParserOptions

--- a/crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py
+++ b/crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Compare buffer handling in two release wheels; requires pyperf and memray.
+
+Run from the repository root with --baseline-python and --candidate-python
+pointing to environments containing the two wheels. Results are JSON on stdout.
+Each of seven pairs alternates which interpreter runs first. Each timing is the
+median of three measurements of 200 complete streams. Allocation tracking is a
+separate measurement of 100 streams after ten warmup streams.
+"""
+
+import argparse
+import json
+from pathlib import Path
+import runpy
+import statistics
+import subprocess
+import sys
+import tempfile
+import timeit
+
+
+def measure(mode):
+    import memray
+    from jsonmodem import JsonModem
+
+    bench = runpy.run_path(str(Path(__file__).with_name("bench_jiter_chunked.py")))
+    chunks = bench["chunk_bytes"](bench["make_array_strings"](1024), 512)
+
+    class Exporter:
+        """A valid read-only exporter whose owner is not directly visible."""
+
+        def __init__(self, data):
+            self.data = data
+
+        def __buffer__(self, flags):
+            return memoryview(self.data)
+
+    def byte_events(data):
+        parser = JsonModem(byte_views=True)
+        count = 0
+        for chunk in data:
+            count += sum(1 for _ in parser.feed(chunk))
+        count += sum(1 for _ in parser.finish())
+        return count
+
+    events = bench["run_jsonmodem_events_chunked"]
+    cases = {
+        "bytes": (events, chunks),
+        "bytearray": (events, [bytearray(chunk) for chunk in chunks]),
+        "memoryview": (events, [memoryview(chunk) for chunk in chunks]),
+        "byte_views_bytes": (byte_events, chunks),
+        "byte_views_exporter": (byte_events, [Exporter(chunk) for chunk in chunks]),
+    }
+    results = {}
+    for name, (function, data) in cases.items():
+        def run():
+            return function(data)
+
+        count = run()
+        if mode == "time":
+            samples = timeit.repeat(run, number=200, repeat=3)
+            results[name] = {"ns": statistics.median(samples) * 1e9 / 200, "events": count}
+        else:
+            for _ in range(10):
+                run()
+            with tempfile.TemporaryDirectory() as directory:
+                artifact = Path(directory) / "allocations.bin"
+                with memray.Tracker(str(artifact), native_traces=True, trace_python_allocators=True):
+                    for _ in range(100):
+                        run()
+                reader = memray.FileReader(str(artifact))
+                frees = {memray.AllocatorType.FREE, memray.AllocatorType.PYMALLOC_FREE, memray.AllocatorType.MUNMAP}
+                allocations = sum(record.n_allocations for record in reader.get_allocation_records() if record.allocator not in frees)
+                results[name] = {
+                    "allocations_per_stream": allocations / 100,
+                    "peak_tracked_bytes": reader.metadata.peak_memory,
+                    "events": count,
+                }
+    return results
+
+
+def compare(baseline, candidate):
+    interpreters = {"baseline": baseline, "candidate": candidate}
+
+    def invoke(python, mode):
+        output = subprocess.check_output([python, __file__, "--worker", mode], text=True)
+        return json.loads(output)
+
+    timings = {name: [] for name in interpreters}
+    for pair in range(7):
+        order = list(interpreters) if pair % 2 == 0 else list(reversed(interpreters))
+        for name in order:
+            timings[name].append(invoke(interpreters[name], "time"))
+    allocations = {name: invoke(python, "memory") for name, python in interpreters.items()}
+    summary = {}
+    for case in timings["baseline"][0]:
+        times = {name: [sample[case]["ns"] for sample in samples] for name, samples in timings.items()}
+        ratios = [new / old for new, old in zip(times["candidate"], times["baseline"])]
+        counts = {sample[case]["events"] for samples in timings.values() for sample in samples}
+        assert len(counts) == 1, f"different event counts for {case}"
+        summary[case] = {
+            "median_ns": {name: statistics.median(samples) for name, samples in times.items()},
+            "paired_ratio_median": statistics.median(ratios),
+            "paired_ratio_range": [min(ratios), max(ratios)],
+            "allocations": {name: results[case] for name, results in allocations.items()},
+        }
+    return {"summary": summary, "timings": timings}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-python")
+    parser.add_argument("--candidate-python", default=sys.executable)
+    parser.add_argument("--worker", choices=["time", "memory"], help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if sys.version_info < (3, 12):
+        parser.error("Python 3.12 or later is required for the Python exporter case")
+    if args.worker:
+        result = measure(args.worker)
+    else:
+        if not args.baseline_python:
+            parser.error("--baseline-python is required")
+        result = compare(args.baseline_python, args.candidate_python)
+    print(json.dumps(result, indent=2))

--- a/crates/jsonmodem-py/benchmarks/requirements-bench.txt
+++ b/crates/jsonmodem-py/benchmarks/requirements-bench.txt
@@ -1,4 +1,5 @@
 pyperf
+memray
 orjson
 msgspec
 jiter

--- a/crates/jsonmodem-py/src/lib.rs
+++ b/crates/jsonmodem-py/src/lib.rs
@@ -3755,7 +3755,7 @@ unsafe extern "C" {
 }
 
 fn with_buffer_text<T>(
-    _py: Python<'_>,
+    py: Python<'_>,
     data: &Bound<'_, PyAny>,
     caller: &str,
     f: impl FnOnce(&str) -> PyResult<T>,
@@ -3776,19 +3776,35 @@ fn with_buffer_text<T>(
         )))));
     }
 
+    let immutable = if let Ok(memoryview) = data.downcast::<PyMemoryView>() {
+        memoryview
+            .getattr(pyo3::intern!(py, "obj"))?
+            .is_exact_instance_of::<PyBytes>()
+    } else {
+        false
+    };
     let bytes = if guard.view.len == 0 {
         &[]
     } else {
+        // SAFETY: the exporter supplies readable storage and the guard holds
+        // its export. No Python callback occurs before the copy below.
         unsafe { std::slice::from_raw_parts(guard.view.buf.cast::<u8>(), guard.view.len as usize) }
     };
-    let text = core::str::from_utf8(bytes).map_err(|err| {
+    // f can allocate Python objects and run GC callbacks on older interpreters.
+    // A read-only export alone does not make its backing storage immutable.
+    let bytes = if immutable {
+        Cow::Borrowed(bytes)
+    } else {
+        Cow::Owned(bytes.to_vec())
+    };
+    let text = core::str::from_utf8(&bytes).map_err(|err| {
         PyTypeError::new_err(format!("{caller} input bytes are not valid UTF-8: {err}"))
     });
     Ok(Some(text.and_then(f)))
 }
 
 fn with_readonly_byte_text<T>(
-    _py: Python<'_>,
+    py: Python<'_>,
     data: &Bound<'_, PyAny>,
     caller: &str,
     f: impl FnOnce(&str, &Bound<'_, PyMemoryView>) -> PyResult<T>,
@@ -3801,8 +3817,17 @@ fn with_readonly_byte_text<T>(
 
     const PYBUF_SIMPLE: c_int = 0;
 
+    // Acquire the retained export before validating or borrowing any text.
+    // Asking data for another export afterward could call Python and return
+    // different storage, or mutate the bytes we have already validated.
+    let source = PyMemoryView::from(data).map_err(|_| {
+        PyTypeError::new_err(format!(
+            "{caller} expected bytes or a read-only contiguous memoryview"
+        ))
+    })?;
     let mut view = PyBufferView::new();
-    let status = unsafe { PyObject_GetBuffer(data.as_ptr(), &mut view, PYBUF_SIMPLE) };
+    // SAFETY: source is a built-in memoryview retaining the acquired export.
+    let status = unsafe { PyObject_GetBuffer(source.as_ptr(), &mut view, PYBUF_SIMPLE) };
     if status != 0 {
         unsafe { ffi::PyErr_Clear() };
         return Err(PyTypeError::new_err(format!(
@@ -3827,24 +3852,34 @@ fn with_readonly_byte_text<T>(
             "{caller} requires a bytes-like input with itemsize 1 for no-copy payload views"
         )));
     }
-    if let Ok(memoryview) = data.downcast::<PyMemoryView>() {
-        let owner = memoryview.getattr("obj")?;
-        if owner.downcast::<PyBytes>().is_err() {
-            return Err(PyTypeError::new_err(format!(
-                "{caller} requires memoryview input backed by bytes for stable no-copy payload views"
-            )));
-        }
+    let owner = source.getattr(pyo3::intern!(py, "obj"))?;
+    if data.is_instance_of::<PyMemoryView>() && owner.downcast::<PyBytes>().is_err() {
+        return Err(PyTypeError::new_err(format!(
+            "{caller} requires memoryview input backed by bytes for stable no-copy payload views"
+        )));
+    }
+
+    if !owner.is_exact_instance_of::<PyBytes>() {
+        // Copy through the built-in memoryview before creating a Rust borrow.
+        // Unknown exporters may expose mutable storage as read-only.
+        let snapshot = source.call_method0("tobytes")?.downcast_into::<PyBytes>()?;
+        let source = PyMemoryView::from(snapshot.as_any())?;
+        let text = core::str::from_utf8(snapshot.as_bytes()).map_err(|err| {
+            PyTypeError::new_err(format!("{caller} input bytes are not valid UTF-8: {err}"))
+        })?;
+        return f(text, &source);
     }
 
     let bytes = if guard.view.len == 0 {
         &[]
     } else {
+        // SAFETY: this exact export is backed by immutable bytes. The guard
+        // and source keep it alive, including while f allocates Python objects.
         unsafe { std::slice::from_raw_parts(guard.view.buf.cast::<u8>(), guard.view.len as usize) }
     };
     let text = core::str::from_utf8(bytes).map_err(|err| {
         PyTypeError::new_err(format!("{caller} input bytes are not valid UTF-8: {err}"))
     })?;
-    let source = PyMemoryView::from(data)?;
     f(text, &source)
 }
 

--- a/crates/jsonmodem-py/src/lib.rs
+++ b/crates/jsonmodem-py/src/lib.rs
@@ -181,6 +181,8 @@ fn build_view_event(
         .into_bound(py)
         .into_any()
         .unbind();
+    // SAFETY: the new tuple is private, indices are in bounds, and SetItem
+    // steals each owned reference. DECREF cleans up any partially filled tuple.
     unsafe {
         let tuple_ptr = ffi::PyTuple_New(3);
         if tuple_ptr.is_null() {
@@ -313,6 +315,8 @@ fn build_path_tuple<'py>(
         return Ok(PyTuple::empty(py));
     }
 
+    // SAFETY: each index belongs to the newly allocated, private tuple. Each
+    // pair is transferred exactly once; DECREF handles incomplete initialization.
     unsafe {
         let tuple_ptr = ffi::PyTuple_New(path.len() as ffi::Py_ssize_t);
         if tuple_ptr.is_null() {
@@ -370,6 +374,8 @@ fn build_path_tuple_for_event(py: Python<'_>, path: &[OwnedPathComponent]) -> Py
         return Ok(PyTuple::empty(py).into_any().unbind());
     }
 
+    // SAFETY: SetItem receives an in-bounds index and an owned reference in a
+    // private tuple. Failure releases the tuple and all initialized elements.
     unsafe {
         let tuple_ptr = ffi::PyTuple_New(path.len() as ffi::Py_ssize_t);
         if tuple_ptr.is_null() {
@@ -795,6 +801,8 @@ impl PyPathView {
             return Ok(PyTuple::empty(py).into_any().unbind());
         }
 
+        // SAFETY: the slice indices are checked against self.path, and every
+        // target index is within the private tuple allocated here.
         unsafe {
             let tuple_ptr = ffi::PyTuple_New(length as ffi::Py_ssize_t);
             if tuple_ptr.is_null() {

--- a/crates/jsonmodem-py/tests/test_buffer_safety.py
+++ b/crates/jsonmodem-py/tests/test_buffer_safety.py
@@ -2,11 +2,24 @@
 
 import gc
 import json
+import os
+from pathlib import Path
+import subprocess
 import sys
 
 import pytest
 
 from jsonmodem import JsonModem, JsonModemSyntaxError, JsonModemValues
+
+
+def test_gc_callback_cannot_change_text_being_parsed():
+    runner = os.environ.get("JSONMODEM_MEMORY_RUNNER")
+    command = [runner] if runner else []
+    script = Path(__file__).resolve().parents[3] / "scripts" / "gc_buffer_regression.py"
+    result = subprocess.run(
+        [*command, sys.executable, str(script)], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 @pytest.mark.parametrize("factory", [bytes, bytearray, memoryview])
@@ -177,17 +190,17 @@ def test_python_exporter_releases_every_acquired_buffer(data):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Python buffer methods require 3.12")
-def test_byte_payload_keeps_python_exporter_alive_until_release():
+def test_byte_payload_snapshots_unknown_python_exporter():
     class Exporter:
-        """Owns immutable storage used by a no-copy payload."""
+        """Owns storage whose immutability cannot be established by the caller."""
 
         def __init__(self):
             self.active = 0
-            self.data = bytes(bytearray(b'["value"]'))
+            self.data = bytearray(b'["value"]')
 
         def __buffer__(self, flags):
             self.active += 1
-            return memoryview(self.data)
+            return memoryview(self.data).toreadonly()
 
         def __release_buffer__(self, buffer):
             self.active -= 1
@@ -199,7 +212,10 @@ def test_byte_payload_keeps_python_exporter_alive_until_release():
     del parser, events
     gc.collect()
     assert payload.tobytes() == b"value"
-    assert source.active > 0
+    assert source.active == 0
+    assert isinstance(payload.obj, bytes)
+    source.data[:] = b"changed"
+    assert payload.tobytes() == b"value"
     payload.release()
     gc.collect()
     assert source.active == 0

--- a/crates/jsonmodem-py/tests/test_buffer_safety.py
+++ b/crates/jsonmodem-py/tests/test_buffer_safety.py
@@ -1,0 +1,238 @@
+"""Buffer ownership and Python object lifetime checks for the streaming APIs."""
+
+import gc
+import json
+import sys
+
+import pytest
+
+from jsonmodem import JsonModem, JsonModemSyntaxError, JsonModemValues
+
+
+@pytest.mark.parametrize("factory", [bytes, bytearray, memoryview])
+@pytest.mark.parametrize("parser_type", [JsonModem, JsonModemValues])
+def test_empty_and_invalid_utf8_release_input(factory, parser_type):
+    parser = parser_type()
+    assert list(parser.feed(factory(b""))) == []
+    with pytest.raises(TypeError, match="valid UTF-8"):
+        list(parser.feed(factory(b'"\xff"')))
+    list(parser.feed(factory(b'["ok"]')))
+    list(parser.finish())
+
+
+@pytest.mark.parametrize("parser_type", [JsonModem, JsonModemValues])
+def test_mutable_input_can_resize_after_success_and_error(parser_type):
+    for data in [b'["ok"]', b'"\xff"', b'[?]']:
+        source = bytearray(data)
+        parser = parser_type()
+        try:
+            events = list(parser.feed(source))
+        except (TypeError, JsonModemSyntaxError):
+            events = []
+        # A leaked Py_buffer would keep bytearray resizing disabled.
+        source.extend(b"extra")
+        del events, parser
+        source.clear()
+
+
+@pytest.mark.parametrize("parser_type", [JsonModem, JsonModemValues])
+def test_released_and_noncontiguous_views_are_rejected(parser_type):
+    released = memoryview(b'["ok"]')
+    released.release()
+    for source in [released, memoryview(b'["ok"]')[::2]]:
+        with pytest.raises((TypeError, ValueError, BufferError)):
+            list(parser_type().feed(source))
+
+
+@pytest.mark.parametrize("byte_views", [False, True])
+def test_sliced_readonly_buffer_and_payload_outlive_input(byte_views):
+    source = bytes(bytearray(b'prefix{"outer":[{"text":"value"}]}suffix'))
+    view = memoryview(source)[6:-6]
+    parser = JsonModem(byte_views=byte_views)
+    events = list(parser.feed(view))
+    list(parser.finish())
+    view.release()
+    del source, view, parser
+    gc.collect()
+    kind, path, payload = next(event for event in events if event[0] == "string")
+    assert kind == "string"
+    expected = (("key", "outer"), ("index", 0), ("key", "text"))
+    assert tuple(path) == expected
+    assert path[::-1] == expected[::-1]
+    assert path[::2] == expected[::2]
+    assert path[-100:100] == expected
+    assert path[1:1] == ()
+    with pytest.raises(ValueError):
+        path[::0]
+    if byte_views:
+        assert payload["fragment"].tobytes() == b"value"
+    else:
+        assert path.as_tuple() == expected
+        assert payload.fragment == "value"
+
+
+def test_owned_events_do_not_change_after_bytearray_mutation():
+    source = bytearray(b'{"text":"original"}')
+    parser = JsonModem()
+    events = list(parser.feed(source))
+    source[:] = b"replaced"
+    assert events[1][2].fragment == "original"
+    assert events[1][1].as_tuple() == (("key", "text"),)
+
+
+def test_values_outlive_parser_and_input():
+    source = bytearray(b'{"items":[{"text":"value"}]}')
+    parser = JsonModemValues()
+    events = list(parser.feed(source))
+    list(parser.finish())
+    value = events[-1][1]
+    child = value["items"][0]["text"]
+    del parser, source, events
+    gc.collect()
+    assert child.snapshot() == "value"
+    assert value.snapshot() == {"items": [{"text": "value"}]}
+
+
+@pytest.mark.parametrize("byte_views", [False, True])
+def test_iterator_drop_and_repeated_allocation_preserve_saved_events(byte_views):
+    saved = []
+    for index in range(128):
+        parser = JsonModem(byte_views=byte_views)
+        events = parser.feed(f'{{"text":"value{index}"}}'.encode())
+        assert next(events)[0] == "object_begin"
+        saved.append(next(events))
+        del events, parser
+    gc.collect()
+    for index, (_, path, payload) in enumerate(saved):
+        assert tuple(path) == (("key", "text"),)
+        fragment = payload["fragment"] if byte_views else payload.fragment
+        if isinstance(fragment, memoryview):
+            fragment = fragment.tobytes().decode()
+        assert fragment == f"value{index}"
+
+
+def test_chunk_generator_exception_releases_buffer():
+    source = bytearray(b'{"text":"value"}')
+
+    def chunks():
+        yield source
+        raise RuntimeError("chunk generator failed")
+
+    with pytest.raises(RuntimeError, match="chunk generator failed"):
+        list(JsonModem().feed(chunks()))
+    source.clear()
+
+
+def test_all_single_byte_string_mutations_release_input():
+    for byte in range(256):
+        source = bytearray(b'["a' + bytes([byte]) + b'"]')
+        try:
+            expected = json.loads(source)
+        except (ValueError, UnicodeDecodeError):
+            expected = None
+        parser = JsonModemValues()
+        try:
+            events = list(parser.feed(source))
+            events.extend(parser.finish())
+        except (TypeError, JsonModemSyntaxError):
+            assert expected is None
+        else:
+            assert expected is not None
+            assert events[-1][1].snapshot() == expected
+        source.clear()
+
+
+def test_contiguous_multidimensional_buffer_preserves_byte_order():
+    source = memoryview(b'["ok"]').cast("B", shape=[2, 3])
+    parser = JsonModem()
+    events = list(parser.feed(source))
+    list(parser.finish())
+    assert events[1][2].fragment == "ok"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python buffer methods require 3.12")
+@pytest.mark.parametrize("data", [b'["ok"]', b'"\xff"'])
+def test_python_exporter_releases_every_acquired_buffer(data):
+    class Exporter:
+        """Counts live views without fabricating native buffer metadata."""
+
+        def __init__(self):
+            self.active = 0
+
+        def __buffer__(self, flags):
+            self.active += 1
+            return memoryview(data)
+
+        def __release_buffer__(self, buffer):
+            self.active -= 1
+
+    source = Exporter()
+    parser = JsonModem()
+    if b"\xff" in data:
+        with pytest.raises(TypeError, match="valid UTF-8"):
+            list(parser.feed(source))
+    else:
+        list(parser.feed(source))
+    assert source.active == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python buffer methods require 3.12")
+def test_byte_payload_keeps_python_exporter_alive_until_release():
+    class Exporter:
+        """Owns immutable storage used by a no-copy payload."""
+
+        def __init__(self):
+            self.active = 0
+            self.data = bytes(bytearray(b'["value"]'))
+
+        def __buffer__(self, flags):
+            self.active += 1
+            return memoryview(self.data)
+
+        def __release_buffer__(self, buffer):
+            self.active -= 1
+
+    source = Exporter()
+    parser = JsonModem(byte_views=True)
+    events = list(parser.feed(source))
+    payload = events[1][2]["fragment"]
+    del parser, events
+    gc.collect()
+    assert payload.tobytes() == b"value"
+    assert source.active > 0
+    payload.release()
+    gc.collect()
+    assert source.active == 0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python buffer methods require 3.12")
+def test_failed_export_does_not_call_release():
+    class Exporter:
+        """Fails before returning storage to CPython."""
+
+        def __buffer__(self, flags):
+            raise BufferError("export failed")
+
+        def __release_buffer__(self, buffer):
+            pytest.fail("release called without a successful acquisition")
+
+    with pytest.raises(TypeError):
+        list(JsonModem().feed(Exporter()))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python buffer methods require 3.12")
+def test_byte_views_parse_the_same_export_as_the_retained_payload():
+    class Exporter:
+        """Returns different immutable storage on a later acquisition."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def __buffer__(self, flags):
+            self.calls += 1
+            return memoryview(b'["first"]' if self.calls <= 2 else b'["second"]')
+
+    source = Exporter()
+    parser = JsonModem(byte_views=True)
+    events = list(parser.feed(source))
+    assert events[1][2]["fragment"].tobytes() == b"first"

--- a/crates/jsonmodem/Cargo.toml
+++ b/crates/jsonmodem/Cargo.toml
@@ -47,6 +47,10 @@ path = "tests/jsonmodem_values/mod.rs"
 name = "fuzz_regressions"
 path = "tests/fuzz_regressions.rs"
 
+[[test]]
+name = "memory_safety"
+path = "tests/memory_safety.rs"
+
 [[example]]
 name = "profile_events"
 path = "examples/profile_events.rs"

--- a/crates/jsonmodem/src/backend/std/value_zipper.rs
+++ b/crates/jsonmodem/src/backend/std/value_zipper.rs
@@ -6,6 +6,9 @@ use super::{StdPath, value::Value};
 use crate::path::{Path, PathItem};
 
 #[derive(Debug)]
+/// Caches pointers along the parser's current branch of an owned value tree.
+/// Descendant pointers must be discarded before replacing or growing an
+/// ancestor.
 pub struct ValueZipper {
     root: Box<Value>,
     path_nodes: Vec<NonNull<Value>>,
@@ -59,6 +62,8 @@ impl ValueZipper {
         mutate(slot);
         let slot_ptr = core::ptr::from_mut::<Value>(slot);
         let path = &self.path_components;
+        // SAFETY: align_path returned this live leaf; only the separate path
+        // vector was borrowed afterward. The result borrows the whole zipper.
         let leaf = unsafe { &*slot_ptr };
         (path, leaf)
     }
@@ -67,6 +72,7 @@ impl ValueZipper {
     pub(crate) fn with_leaf<'a>(&'a mut self, path: &Path) -> (&'a StdPath, &'a Value) {
         let slot = core::ptr::from_mut::<Value>(self.align_path(path));
         let path = &self.path_components;
+        // SAFETY: borrowing path_components does not move the tree's values.
         let leaf = unsafe { &*slot };
         (path, leaf)
     }
@@ -88,6 +94,8 @@ impl ValueZipper {
                 let component = path
                     .last()
                     .expect("path depth greater than current depth implies non-empty path");
+                // SAFETY: the current node is live and exclusively borrowed.
+                // No descendant pointers exist while its container may grow.
                 let child = descend_one(unsafe { parent_ptr.as_mut() }, component);
                 let child_ptr = NonNull::from(child);
                 self.path_nodes.push(child_ptr);
@@ -112,6 +120,8 @@ impl ValueZipper {
                         self.path_nodes.pop();
                         self.path_components.pop();
                         let mut parent_ptr = self.current_ptr();
+                        // SAFETY: the old child pointer was removed before
+                        // descend_one can grow the parent's container.
                         let child = descend_one(unsafe { parent_ptr.as_mut() }, last);
                         let child_ptr = NonNull::from(child);
                         self.path_nodes.push(child_ptr);
@@ -121,6 +131,8 @@ impl ValueZipper {
             }
         }
 
+        // SAFETY: the branches above retain only pointers to live ancestors
+        // and the current leaf. The exclusive borrow prevents concurrent access.
         unsafe { self.current_ptr().as_mut() }
     }
 
@@ -171,5 +183,82 @@ fn descend_one<'a>(current: &'a mut Value, component: &PathItem) -> &'a mut Valu
             }
             array.get_mut(idx).expect("array resized to contain index")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{format, vec};
+
+    use super::*;
+
+    #[test]
+    fn memory_safety_array_growth_and_root_reuse() {
+        let mut zipper = ValueZipper::new();
+        for round in 0..3 {
+            zipper.insert_value(&vec![], Value::Array(Vec::new()));
+            for index in 0..64 {
+                let path = vec![PathItem::Index(index)];
+                let (actual_path, value) = zipper.with_leaf_mut(&path, |value| {
+                    *value = Value::Number(f64::from(u32::try_from(round + index).unwrap()));
+                });
+                assert_eq!(actual_path, &path);
+                assert_eq!(
+                    value,
+                    &Value::Number(f64::from(u32::try_from(round + index).unwrap()))
+                );
+            }
+            zipper.with_leaf(&vec![]);
+            let expected = Value::Array(
+                (0..64)
+                    .map(|index| Value::Number(f64::from(u32::try_from(round + index).unwrap())))
+                    .collect(),
+            );
+            assert_eq!(zipper.read_root(), &expected);
+            assert_eq!(zipper.take_root(), expected);
+            assert_eq!(zipper.read_root(), &Value::Null);
+            assert!(zipper.path_nodes.is_empty());
+        }
+    }
+
+    #[test]
+    fn memory_safety_map_growth_nested_replacement_and_read_root() {
+        let mut zipper = ValueZipper::new();
+        let mut expected = BTreeMap::new();
+        for index in 0..64 {
+            let key: Arc<str> = format!("key{index:03}").into();
+            let parent = vec![PathItem::Key(key.clone())];
+            zipper.insert_value(&parent, Value::Array(Vec::new()));
+            for child in 0..8 {
+                let path = vec![parent[0].clone(), PathItem::Index(child)];
+                zipper.insert_value(&path, Value::Boolean(child % 2 == 0));
+                assert!(matches!(zipper.read_root(), Value::Object(_)));
+                assert_eq!(zipper.with_leaf(&path).1, &Value::Boolean(child % 2 == 0));
+            }
+            zipper.with_leaf(&parent);
+            zipper.insert_value(&parent, Value::String(format!("replaced{index}")));
+            expected.insert(key, Value::String(format!("replaced{index}")));
+        }
+        zipper.with_leaf(&vec![]);
+        assert_eq!(zipper.take_root(), Value::Object(expected));
+    }
+
+    #[test]
+    fn memory_safety_repeated_key_sparse_index_and_ancestor_replacement() {
+        let mut zipper = ValueZipper::new();
+        let parent = vec![PathItem::Key("key".into())];
+        zipper.insert_value(&parent, Value::Null);
+        let child = vec![parent[0].clone(), PathItem::Index(32)];
+        zipper.insert_value(&child, Value::Boolean(true));
+        zipper.with_leaf(&parent);
+        let mut expected = vec![Value::Null; 33];
+        expected[32] = Value::Boolean(true);
+        assert_eq!(zipper.with_leaf(&parent).1, &Value::Array(expected));
+        zipper.insert_value(&parent, Value::Null);
+        zipper.insert_value(&child, Value::Boolean(false));
+        zipper.with_leaf(&parent);
+        zipper.with_leaf(&vec![]);
+        zipper.insert_value(&vec![], Value::Null);
+        assert_eq!(zipper.take_root(), Value::Null);
     }
 }

--- a/crates/jsonmodem/src/parser/scanner/mod.rs
+++ b/crates/jsonmodem/src/parser/scanner/mod.rs
@@ -337,6 +337,10 @@ impl<'src> Scanner<'src> {
                             let slice = &self.batch.as_bytes()[start..end];
                             match &mut self.scratch {
                                 CaptureBuf::Text(s) => {
+                                    #[cfg(any(test, miri))]
+                                    assert!(core::str::from_utf8(slice).is_ok());
+                                    // SAFETY: the anchor and cursor are character boundaries in
+                                    // batch.
                                     s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
                                 }
                                 CaptureBuf::Raw(b) => b.extend_from_slice(slice),
@@ -602,6 +606,9 @@ impl<'src> Scanner<'src> {
                 let slice = &self.batch.as_bytes()[start..end];
                 match &mut self.scratch {
                     CaptureBuf::Text(s) => {
+                        #[cfg(any(test, miri))]
+                        assert!(core::str::from_utf8(slice).is_ok());
+                        // SAFETY: the anchor and cursor are character boundaries in batch.
                         s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
                     }
                     CaptureBuf::Raw(b) => b.extend_from_slice(slice),
@@ -628,6 +635,8 @@ impl<'src> Scanner<'src> {
     fn push_ascii_to_scratch(&mut self, slice: &[u8]) {
         match &mut self.scratch {
             CaptureBuf::Text(s) => {
+                #[cfg(any(test, miri))]
+                assert!(core::str::from_utf8(slice).is_ok());
                 // SAFETY: caller guarantees ASCII, hence valid UTF-8.
                 s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
             }
@@ -652,6 +661,9 @@ impl<'src> Scanner<'src> {
         let slice = &self.batch.as_bytes()[start..self.byte_idx];
         match &mut self.scratch {
             CaptureBuf::Text(s) => {
+                #[cfg(any(test, miri))]
+                assert!(core::str::from_utf8(slice).is_ok());
+                // SAFETY: the anchor and cursor are character boundaries in batch.
                 s.push_str(unsafe { core::str::from_utf8_unchecked(slice) });
             }
             CaptureBuf::Raw(b) => b.extend_from_slice(slice),

--- a/crates/jsonmodem/src/parser/scanner/tests.rs
+++ b/crates/jsonmodem/src/parser/scanner/tests.rs
@@ -592,3 +592,64 @@ fn newline_updates_positions_across_ring_and_batch() {
     assert_eq!(s.line, 3);
     assert_eq!(s.col, 1);
 }
+
+#[test]
+fn memory_safety_prefix_copy_operations() {
+    for prefix in [
+        "",
+        "ascii",
+        "\u{e9}",
+        "\u{20ac}",
+        "\u{1f600}",
+        "a\u{e9}\u{20ac}\u{1f600}",
+    ] {
+        for operation in 0..3 {
+            let batch = alloc::format!("{prefix}\"tail");
+            let mut scanner = Scanner::from_state(carry(""), &batch);
+            for _ in prefix.chars() {
+                scanner.consume();
+            }
+            // Exercise copying from batch without a previously captured prefix.
+            scanner.scratch = CaptureBuf::Text(String::new());
+            match operation {
+                0 => {
+                    let state = scanner.finish();
+                    assert_eq!(state.test_scratch_text(), Some(prefix));
+                    assert_eq!(state.test_ring_bytes(), b"\"tail");
+                }
+                1 => {
+                    scanner.switch_to_owned_prefix_if_needed();
+                    scanner.switch_to_owned_prefix_if_needed();
+                    assert_eq!(scanner.scratch.as_text_mut(), prefix);
+                }
+                _ => {
+                    scanner.ensure_prefix_copied();
+                    scanner.ensure_prefix_copied();
+                    assert_eq!(scanner.scratch.as_text_mut(), prefix);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn memory_safety_owned_ascii_and_raw_captures() {
+    let mut scanner = Scanner::from_state(carry(""), "ascii\"tail");
+    scanner.switch_to_owned_prefix_if_needed();
+    scanner.ensure_anchor_started();
+    scanner.switch_to_owned_prefix_if_needed();
+    assert_eq!(scanner.consume_string_ascii_fast(), 5);
+    assert!(matches!(scanner.emit(), Capture::Owned(text) if text == "ascii"));
+
+    let mut scanner = Scanner::from_state(carry(""), "abc");
+    scanner.ensure_raw();
+    scanner.push_ascii_to_scratch(b"raw");
+    assert!(matches!(scanner.emit(), Capture::Raw(bytes) if bytes == b"raw"));
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: core::str::from_utf8(slice).is_ok()")]
+fn memory_safety_invalid_utf8_fails_before_unchecked_conversion() {
+    let mut scanner = Scanner::from_state(carry(""), "");
+    scanner.push_ascii_to_scratch(&[0xff]);
+}

--- a/crates/jsonmodem/tests/memory_safety.rs
+++ b/crates/jsonmodem/tests/memory_safety.rs
@@ -1,0 +1,158 @@
+//! Deterministic streaming assertions that run without snapshot filesystem
+//! access.
+
+use jsonmodem::{
+    BufferOptions, BufferedEvent, JsonModemBuffers, JsonModemValues, ParserOptions, Value,
+    ValuesOptions, lending_iterator::LendingIterator,
+};
+
+fn final_values(chunks: &[&str]) -> Vec<serde_json::Value> {
+    let mut parser = JsonModemValues::with_options(
+        ParserOptions::default().with_allow_multiple_json_values(true),
+        ValuesOptions::default(),
+    );
+    let mut values = Vec::new();
+    for chunk in chunks {
+        for event in parser.feed(chunk).to_iter() {
+            let event = event.expect("valid streaming input");
+            if event.is_final {
+                values.push(serde_json::from_str(&event.value.to_string()).unwrap());
+            }
+        }
+    }
+    for event in parser.finish().to_iter() {
+        let event = event.expect("complete streaming input");
+        if event.is_final {
+            values.push(serde_json::from_str(&event.value.to_string()).unwrap());
+        }
+    }
+    values
+}
+
+fn completed_strings(chunks: &[&str]) -> Vec<(String, String)> {
+    let mut parser = JsonModemBuffers::string(
+        ParserOptions::default().with_allow_multiple_json_values(true),
+        BufferOptions::default(),
+    );
+    let mut strings = Vec::new();
+    for chunk in chunks {
+        for event in parser.feed(chunk).to_iter() {
+            if let BufferedEvent::String {
+                path,
+                value,
+                is_final: true,
+                ..
+            } = event.unwrap()
+            {
+                strings.push((format!("{path:?}"), value.unwrap().as_ref().to_owned()));
+            }
+        }
+    }
+    for event in parser.finish().to_iter() {
+        event.unwrap();
+    }
+    strings
+}
+
+#[test]
+fn every_character_boundary_preserves_values_and_strings() {
+    for input in [
+        r#"["a\n"]"#,
+        r#"["\u00e9"]"#,
+        r#"["\u20ac"]"#,
+        r#"{"a":"\ud83d\ude00"}"#,
+        r#"{"":""}"#,
+        "{\"\u{e9}\":\"\u{20ac}\u{1f600}\"}",
+        r#"{"a":[null],"a":{}}"#,
+        "[[],{},[true]]",
+    ] {
+        let expected: serde_json::Value = serde_json::from_str(input).unwrap();
+        let strings = completed_strings(&[input]);
+        for split in 0..=input.len() {
+            if input.is_char_boundary(split) {
+                let chunks = [&input[..split], &input[split..]];
+                assert_eq!(
+                    final_values(&chunks),
+                    std::slice::from_ref(&expected),
+                    "split {split}: {input}"
+                );
+                assert_eq!(
+                    completed_strings(&chunks),
+                    strings,
+                    "split {split}: {input}"
+                );
+            }
+        }
+        let chunks: Vec<_> = input
+            .char_indices()
+            .map(|(start, ch)| &input[start..start + ch.len_utf8()])
+            .collect();
+        assert_eq!(final_values(&chunks), [expected]);
+        assert_eq!(completed_strings(&chunks), strings);
+    }
+}
+
+#[test]
+fn generated_container_growth_and_multiple_roots() {
+    let cases: usize = std::env::var("JSONMODEM_SAFETY_CASES")
+        .unwrap_or_else(|_| "32".into())
+        .parse()
+        .expect("positive case count");
+    assert!(cases > 0);
+    eprintln!("JSONMODEM_SAFETY_CASES={cases}; deterministic input indices=0..{cases}");
+    for case in 0..cases {
+        let mut map = serde_json::Map::new();
+        for index in 0..(2 + case % 15) {
+            map.insert(format!("k{index}"), serde_json::Value::Bool(index % 2 == 0));
+        }
+        map.insert(
+            "nested".into(),
+            serde_json::json!([{"text": format!("t{case}")}]),
+        );
+        let expected = serde_json::Value::Object(map);
+        let input = format!("{expected} {expected}");
+        let width = 1 + case % 17;
+        let chunks: Vec<_> = input
+            .as_bytes()
+            .chunks(width)
+            .map(|chunk| std::str::from_utf8(chunk).unwrap())
+            .collect();
+        assert_eq!(final_values(&chunks), [expected.clone(), expected]);
+    }
+}
+
+#[test]
+fn partial_values_survive_iterator_drop_and_finish() {
+    let mut parser = JsonModemValues::with_options(
+        ParserOptions::default(),
+        ValuesOptions::default().with_partial(true),
+    );
+    {
+        let mut events = parser.feed("{\"title\":\"hel");
+        LendingIterator::next(&mut events).unwrap().unwrap();
+    }
+    assert!(matches!(parser.view_root(), Value::Object(_)));
+    let events: Vec<_> = parser.feed("lo\"}").to_iter().map(Result::unwrap).collect();
+    assert!(events.iter().any(|event| event.is_final));
+    let finished: Vec<_> = parser.finish().to_iter().map(Result::unwrap).collect();
+    assert!(finished.is_empty());
+}
+
+#[test]
+fn error_and_early_drop_release_partial_containers() {
+    for input in [r#"{"a":[true,{"text":"partial"#, r#"{"a":[true,?]}"#] {
+        let mut values = JsonModemValues::new(ParserOptions::default());
+        let results: Vec<_> = values.feed(input).to_iter().collect();
+        let errors = results.iter().any(Result::is_err);
+        let final_results: Vec<_> = values.finish().to_iter().collect();
+        assert!(errors || final_results.iter().any(Result::is_err));
+
+        let mut buffers =
+            JsonModemBuffers::string(ParserOptions::default(), BufferOptions::default());
+        let mut events = buffers.feed(input);
+        assert!(events.next().is_some());
+        drop(events);
+        // Dropping a parser with unread input must release borrowed state.
+        drop(buffers);
+    }
+}

--- a/docs/memory-safety-testing.md
+++ b/docs/memory-safety-testing.md
@@ -89,6 +89,8 @@ and a separate virtual environment go under `target/python-memory`. The script
 installs a wheel there; it does not replace the ordinary editable extension.
 It uses `python3` by default. Set `JSONMODEM_MEMORY_PYTHON` to select another
 interpreter, for example `3.13` to match CI.
+CI tests Python 3.9 and 3.13. The older version exercises synchronous garbage
+collection callbacks that can run while `feed()` allocates Python objects.
 
 `scripts/python_memory_runner.rs` starts CPython from a Rust executable linked
 with AddressSanitizer. The extension is built with the same Rust toolchain and
@@ -110,13 +112,40 @@ parser or input is discarded. It tries all 256 single-byte mutations of a short
 JSON string. Python 3.12 and later also exercise Python-defined buffer exporters
 and count buffer acquisitions and releases.
 
+Two regressions found bugs that the original tests missed. One exporter returned
+different immutable bytes for parsing and payload creation. Byte-view mode now
+parses the exact retained export. Another test changed a bytearray from a GC
+callback during Python 3.9 parsing. Ordinary buffer input is now copied unless
+its storage is known to be immutable. `scripts/gc_buffer_regression.py` runs in a
+subprocess and requires actual callbacks inside `feed` on Python 3.9-3.11.
+
 The tuple-building unsafe operations are exercised by saved nested events,
 path conversion, path slicing, and no-copy byte events. The buffer operations
 are exercised through `with_buffer_text`, `with_readonly_byte_text`,
 `supports_buffer_protocol`, and `PyBufferGuard::drop`. The exporter must supply a
 valid allocation for the requested length, and the guard must keep the export
-alive until the Rust borrow ends. Returned no-copy memoryviews must retain their
-own buffer export after the temporary guard releases its export.
+alive until the Rust borrow or copy ends. Unknown read-only exporters are copied
+to immutable bytes before parsing, so their payloads retain the copy. Known
+immutable bytes-backed payloads retain their own export after the temporary
+guard releases its export.
+
+## Measuring buffer-copy cost
+
+`benchmarks/bench_buffer_inputs.py` compares two installed release builds using
+the existing synthetic array-of-strings workload, split into 512-byte chunks.
+Both environments need Python 3.12 or later, `pyperf`, and `memray`. For example:
+
+```sh
+python crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py \
+  --baseline-python /path/to/baseline/bin/python \
+  --candidate-python /path/to/candidate/bin/python > comparison.json
+```
+
+The script alternates the builds' execution order for seven paired measurements.
+Each measurement times 200 streams three times and takes the median. It also
+tracks allocations over 100 streams in separate Memray runs. Allocation counts
+exclude free and unmap records; peak tracked memory is not process RSS. Timings
+on a shared host are evidence for that run, not a performance guarantee.
 
 ## Limits
 

--- a/docs/memory-safety-testing.md
+++ b/docs/memory-safety-testing.md
@@ -1,0 +1,139 @@
+# Memory-safety tests
+
+Run these commands from the repository root:
+
+```sh
+bash .agent/check-miri.sh
+bash .agent/check-py-memory.sh
+```
+
+The first command executes Rust tests under Miri. The second loads an
+AddressSanitizer-instrumented Python extension into CPython. They check different
+operations; neither proves that every possible use is safe.
+
+## Rust tests
+
+Miri needs a Rust nightly toolchain with `miri` and `rust-src`, plus
+`cargo-nextest`. `.agent/setup.sh` installs these tools. The script logs the
+compiler version so a failure can be reproduced with the same nightly. Set
+`JSONMODEM_MEMORY_TOOLCHAIN` to a dated nightly to reproduce a recorded run.
+
+The full suite excludes the Python binding and fuzz executables. It includes
+ordinary Rust tests and saved fuzz regression inputs. It does not run a live
+fuzzer. Tests that render `insta` snapshots remain excluded under Miri;
+`tests/memory_safety.rs` uses plain assertions for the streaming behavior it
+checks, so it does not need snapshot filesystem access.
+
+The targeted tests run with execution seeds 0, 1, and 2 under Stacked Borrows and
+Tree Borrows. These are two models Miri uses to detect invalid overlapping Rust
+references. The execution seed changes choices such as allocation addresses.
+It does not specify the generated JSON inputs. The generated-input test uses
+deterministic indices, defaults to 32 cases, and prints the count. Override it
+with `JSONMODEM_SAFETY_CASES`; the script explicitly forwards that setting into
+Miri's otherwise isolated environment. The two older QuickCheck tests retain
+their existing reduced counts under Miri.
+
+For a focused run:
+
+```sh
+bash .agent/check-miri.sh targeted
+cargo test -p jsonmodem --lib memory_safety
+cargo test -p jsonmodem --test memory_safety
+```
+
+### Scanner
+
+`parser/scanner/mod.rs` has four unchecked UTF-8 conversions. Test and Miri builds
+check the selected bytes before each conversion. These assertions are absent
+from normal release builds.
+
+`memory_safety_prefix_copy_operations` exercises `finish`,
+`switch_to_owned_prefix_if_needed`, and `copy_prefix_to_scratch` with empty,
+ASCII, and multibyte prefixes. Each assumes the anchor and cursor select valid
+character boundaries in the input string. The test deliberately clears captured
+text to exercise the branch that copies from the input batch.
+
+`memory_safety_owned_ascii_and_raw_captures` exercises `push_ascii_to_scratch`,
+whose text branch requires ASCII input. The invalid-UTF-8 test deliberately
+violates that private helper's requirement and expects the test-only assertion
+to panic before unchecked conversion. This confirms the assertion is active
+without creating an invalid Rust string.
+
+The integration test `every_character_boundary_preserves_values_and_strings`
+tries every valid split position in short inputs, then feeds each character
+separately. It covers Unicode escapes, surrogate pairs, multibyte characters,
+empty strings, duplicate keys, and nested containers. Completed values are
+compared with `serde_json`; buffered string events are compared with a single
+feed of the same input.
+
+### ValueZipper
+
+`backend/std/value_zipper.rs` stores pointers to the current value and its
+ancestors. `align_path` must discard pointers to old children before inserting
+into a parent that might move its contents. `with_leaf` and `with_leaf_mut`
+return references tied to the borrow of the zipper, preventing callers from
+mutating the tree while those references remain in use.
+
+Three direct tests exercise all five explicit unsafe operations. They grow
+arrays and ordered maps, read the root between mutations, change siblings,
+replace nested values, insert beyond an array's current end, and reuse the
+zipper after `take_root`. The tests assert values and paths, not just that the
+process survives. Integration tests also exercise generated containers, multiple
+roots, partial values, iterator drop, and cleanup after parse errors.
+
+## Python extension
+
+The native check currently requires Linux x86_64, `uv`, a C linker, `nm` from
+binutils, a Rust nightly, and Python with a shared `libpython`. Build products
+and a separate virtual environment go under `target/python-memory`. The script
+installs a wheel there; it does not replace the ordinary editable extension.
+It uses `python3` by default. Set `JSONMODEM_MEMORY_PYTHON` to select another
+interpreter, for example `3.13` to match CI.
+
+`scripts/python_memory_runner.rs` starts CPython from a Rust executable linked
+with AddressSanitizer. The extension is built with the same Rust toolchain and
+instrumentation. This avoids loading a different compiler's sanitizer runtime.
+The script checks that the imported extension is inside its own environment and
+references `__asan_init`.
+
+Before testing jsonmodem, the script loads `scripts/asan_failure.rs` as a separate
+test library. It deliberately reads beyond an allocation. The check must exit
+unsuccessfully and report `AddressSanitizer: heap-buffer-overflow`; an import
+error or another crash does not count. That library is never linked into the
+production extension. The report is retained in
+`target/python-memory/asan-failure.log`.
+
+`test_buffer_safety.py` exercises successful and failed buffer acquisition,
+invalid UTF-8, input layout rejection, sliced and multidimensional buffers,
+bytearray resizing after success and failure, and saved events after their
+parser or input is discarded. It tries all 256 single-byte mutations of a short
+JSON string. Python 3.12 and later also exercise Python-defined buffer exporters
+and count buffer acquisitions and releases.
+
+The tuple-building unsafe operations are exercised by saved nested events,
+path conversion, path slicing, and no-copy byte events. The buffer operations
+are exercised through `with_buffer_text`, `with_readonly_byte_text`,
+`supports_buffer_protocol`, and `PyBufferGuard::drop`. The exporter must supply a
+valid allocation for the requested length, and the guard must keep the export
+alive until the Rust borrow ends. Returned no-copy memoryviews must retain their
+own buffer export after the temporary guard releases its export.
+
+## Limits
+
+CPython itself and the prebuilt Rust standard library are not instrumented by
+the native script. `PYTHONMALLOC=malloc` makes Python allocations visible to the
+sanitizer allocator, but does not add checks inside CPython. Leak detection is
+disabled because CPython retains allocations during shutdown. Buffer-release
+assertions detect the specific export leaks they exercise; they do not establish
+general leak freedom.
+
+The Python tests do not inject allocation failures into every tuple-construction
+step. Those cleanup branches also require source review. They do not fabricate
+invalid pointers, prove an arbitrary native exporter's allocation size, or
+establish safety under concurrent mutation by another native extension.
+
+Miri does not execute the CPython foreign calls in this setup. The sanitizer
+does not check all Rust reference-aliasing rules. Both tools check executions
+selected by the tests, not all executions. Coverage here means named assumptions
+and tests, not a measured percentage of all unsafe instructions or proof of
+soundness.

--- a/plans/memory-safety-tests/plan.md
+++ b/plans/memory-safety-tests/plan.md
@@ -1,393 +1,198 @@
 # Test unsafe streaming code and Python buffers
 
 
-Status: completed locally on 2026-08-26. Publication was not requested. This plan follows
-`PLANS.md` and uses `plan.md` and `record.md` as requested. Keep Progress,
-Surprises and Discoveries, Decision Log, and Outcomes and Retrospective current.
+Status: implementation complete; upstream publication in progress (2026-08-26).
+This plan follows `PLANS.md`. Keep Progress, Decision Log, and Outcomes current
+until the upstream PR's final checks pass.
 
 ## Purpose / Big Picture
 
 
-Make the memory-safety checks for jsonmodem's streaming parser and Python binding
-specific and reproducible. Before this work, a passing Miri job said little about
-the Python binding because that crate was excluded. Some Rust integration tests
-were also excluded, and the pointer traversal had no dedicated unit tests.
-
-After this work, contributors will have tests tied to the assumptions behind
-each relevant `unsafe` block, a Miri command for the Rust tests, and a native
-memory-checking command for the Python extension. Confirmed defects will have
-regression tests and fixes. Passing these checks will not be described as proof
-that all possible inputs and Python objects are safe.
+Make memory-safety testing reproducible for jsonmodem's streaming scanner,
+raw-pointer value traversal, and Python buffer handling. The previous Miri job
+excluded the Python crate and some Rust integration tests. The new tests found
+two Python input ownership defects, which this branch fixes.
 
 ## Plan Layout
 
 
-`plans/memory-safety-tests/plan.md` owns scope, decisions, and completion status.
-`plans/memory-safety-tests/record.md` holds the safety assumptions, named tests,
-commands, results, and remaining omissions. Follow the existing repository
-convention of storing plans under `plans/<task>/`.
-
-Keep only compact, public evidence in these files. Put build products, full logs,
-generated corpora, and temporary fault-injection programs outside tracked files.
-Before publication, summarize the record and review the diff. No merge is
-authorized by this plan; this cleanup rule applies regardless of merge method.
+This file owns scope and completion status. `record.md` records regressions,
+commands, measurements, and publication evidence. `docs/memory-safety-testing.md`
+maps unsafe operations to tests and explains the tools' limits. Full logs,
+wheels, and generated measurement data remain outside tracked files. Planning
+notes were condensed before publication; their earlier versions remain in Git.
 
 ## Work Boundaries
 
 
-Use branch `dev/friel/memory-safety-tests` in the separate worktree created from
-`upstream/main` at `47a542760f84dd402cecda6476b56dc92dae54e5`. Do not merge or
-cherry-pick the orjson frontend PR to obtain these changes. The base repository
-is `AaronFriel/jsonmodem`; the user's publishing fork is `friel-openai/jsonmodem`.
+Branch `dev/friel/memory-safety-tests` starts directly at upstream
+`47a542760f84dd402cecda6476b56dc92dae54e5`. It does not depend on the separate
+orjson frontend work. Publish from `friel-openai/jsonmodem` to
+`AaronFriel/jsonmodem:main`; do not merge or modify another PR.
 
-The primary files are `crates/jsonmodem/src/parser/scanner/mod.rs`, its
-`tests.rs`, `crates/jsonmodem/src/backend/std/value_zipper.rs`, and
-`crates/jsonmodem-py/src/lib.rs`. Related Rust integration tests, Python tests,
-`.github/workflows/miri.yml`, `.config/nextest.toml`, and `.agent/` test scripts
-are in scope. Follow callers into `parser/mod.rs` and `value_applicator.rs` when
-needed to establish a safety assumption. Do not turn this into a repository-wide
-rewrite or add runtime dependencies for test infrastructure.
-
-Preserve streaming events, partial values, supported buffer inputs, and normal
-performance. Start with tests and test-only assertions. Change production code
-only for a demonstrated defect or a necessary clarification of an unsafe
-operation's preconditions. Record and measure any runtime change.
-
-PR #1 and its active `plans/orjson-security-audit/plan.md` remain separate. That
-audit concerns the frontend and changes made by PR #1; this plan concerns
-upstream streaming code and repeatable memory-safety testing. Do not edit that
-checkout or its plans. If both efforts discover the same defect, coordinate
-which branch owns the fix before publishing duplicate changes. Do not copy
-private source, usage details, payloads, project information, or communications
-into this repository. All test inputs must be synthetic or already public.
+Changes cover `crates/jsonmodem/src/parser/scanner/`,
+`crates/jsonmodem/src/backend/std/value_zipper.rs`, Python buffer handling in
+`crates/jsonmodem-py/src/lib.rs`, their tests, and test tooling. Use only public
+or synthetic inputs. Preserve streaming events, supported valid inputs, and
+borrowing of known immutable storage. Do not add runtime dependencies.
 
 ## Definition of Done
 
 
-Each explicit unsafe operation in the three primary source files has a recorded
-safety assumption, an explanation of how callers enforce it, and named tests
-that exercise it. Any assumption that cannot be tested is listed as a limitation.
-The record distinguishes source inspection, actual Miri execution, and native
-sanitizer execution. It does not infer coverage from compilation or test totals.
+Each explicit unsafe operation in the three source areas has a recorded safety
+assumption and named tests, or an explicit limitation. Relevant Rust tests run
+under Miri, including targeted runs under both reference models with three
+execution seeds. Python tests run with verified native instrumentation. Every
+confirmed defect has a failing baseline and a passing regression after the fix.
 
-Scanner tests check valid UTF-8 at every unchecked conversion in test builds.
-Dedicated ValueZipper tests exercise allocation growth, sibling changes,
-replacement, and root reuse. Relevant behavior currently hidden behind snapshot
-test exclusions has plain assertions that run under Miri. The tests run with
-both reference-aliasing models described below and recorded deterministic seeds.
-
-Python buffer and object-lifetime tests run against an instrumented extension.
-A temporary known-bad program confirms that the native memory checker is active.
-The record states whether CPython itself is instrumented and what remains
-outside detection. There must be no unexplained memory-checking reports.
-
-Existing Rust and Python tests still pass. Every confirmed production defect has
-a minimal reproducer that fails before its fix and passes after. A separate PR,
-when publication is requested, must contain no dependency on PR #1 and have all
-required checks green before it is marked ready. Do not merge either PR.
+Existing tests pass. Performance and allocation changes are measured. The
+separate upstream PR is labeled `jsonmodem` if repository permissions allow it,
+and becomes ready for review after required checks pass on its final head.
+Document any permission limitation rather than bypassing repository controls.
+No merge is authorized.
 
 ## Progress
 
 
-- [x] (2026-08-26 05:26Z) Inspect upstream, the Miri workflow, test exclusions, and buffer handling.
-- [x] (2026-08-26 05:26Z) Create an independent worktree and branch at upstream `47a5427`.
-- [x] (2026-08-26 05:26Z) Write this plan and the initial evidence record.
-- [x] (2026-08-26) Map each unsafe operation to its safety assumptions and named tests; document untested cases.
-- [x] (2026-08-26) Add six scanner/ValueZipper unit tests and four integration tests.
-- [x] (2026-08-26) Pass 188 full-suite Miri tests and all six targeted configurations, each with 32 generated cases.
+- [x] (2026-08-26) Create the independent worktree from upstream `47a5427`.
+- [x] (2026-08-26) Record unsafe assumptions and add six unit tests and four integration tests.
+- [x] (2026-08-26) Pass 188 full-suite Miri tests and six targeted configurations.
 - [x] (2026-08-26) Reproduce and fix exporter reacquisition and Python 3.9 GC mutation of borrowed input.
-- [x] (2026-08-26) Verify native instrumentation with a required failure check; pass 47 Python 3.9 tests and 52 Python 3.13 tests.
-- [x] (2026-08-26) Add CI commands, local scripts, prerequisites, and coverage documentation.
-- [x] (2026-08-26) Measure paired streaming timings and Memray allocations; remove avoidable attribute-name allocations.
-- [x] (2026-08-26) Pass final local checks and independent source review; commit fixes at `2e61d8f` without PR #1 ancestry.
+- [x] (2026-08-26) Verify native instrumentation; pass 47 Python 3.9 tests and 52 Python 3.13 tests.
+- [x] (2026-08-26) Measure streaming time and allocations; remove per-chunk attribute-name allocations.
+- [x] (2026-08-26) Complete local checks and independent source review.
+- [x] (2026-08-26) Refresh upstream once; confirm the base remains `47a5427` and no matching PR exists.
+- [ ] Push the branch and create the upstream draft PR.
+- [ ] Apply the project label, or record the upstream permission limitation.
+- [ ] Verify final hosted checks and mark the PR ready.
 
 ## Surprises and Discoveries
 
 
-The upstream Miri workflow already excludes `jsonmodem-py` and
-`jsonmodem-fuzz`. The exclusions do not depend on PR #1. ValueZipper is unchanged
-between upstream and PR #1. The scanner has a numeric accumulation fix in PR #1,
-but its unchecked UTF-8 conversions and existing tests are already upstream.
+A Python exporter could return one buffer for parsing and a different buffer
+for payload views. Python 3.9 could also run a garbage-collection callback during
+`feed()` and mutate a borrowed bytearray. These are input ownership defects;
+AddressSanitizer did not diagnose the UTF-8 invariant violation. The regression
+tests therefore check behavior as well as native memory errors.
 
-The repository's `.agent/check.sh` compiles a Clippy configuration with
-`cfg(miri)`, but skips actual Miri execution by default. The optional Miri command
-also differs from the workflow's crate exclusions. Neither compilation nor a
-skipped command is execution evidence.
-
-The new Python tests and review found two real defects. Byte-view mode acquired
-different exports for parsing and payload creation. On Python 3.9, synchronous GC
-callbacks could mutate ordinary bytearray input during parsing. Both now have
-before-and-after regression evidence in `record.md`. They also show why passing
-Miri or AddressSanitizer alone would not establish input ownership correctness.
+The existing local check script compiled a Miri configuration for Clippy but
+skipped actual Miri execution by default. Actual execution is now a separate,
+documented command. Long, combined split-input cases were too slow under Miri;
+short cases retain exhaustive split positions, while separate tests cover growth.
 
 ## Decision Log
 
 
-2026-08-26, Codex: Base the work on upstream `47a5427`, not PR #1. All three
-reviewed areas exist upstream, so adding safety tests does not require the
-orjson-compatible API. This permits independent review and merging.
+2026-08-26: Base this work on upstream, since the scanner, ValueZipper, and
+streaming Python binding already exist there. Keep it independently mergeable.
 
-2026-08-26, Codex: Keep one plan with separate Rust and Python milestones.
-Miri interprets Rust operations; the existing CPython calls need a separate
-native test arrangement. Removing the Python exclusion without addressing those
-calls would not establish coverage.
+2026-08-26: Use Miri for Rust and AddressSanitizer plus behavioral regressions for
+Python. Verify instrumentation with a deliberately invalid test library that is
+never linked into the production extension.
 
-2026-08-26, Codex: Prepare the plan and worktree now. Implementation and
-publication remain unchecked; no source edits or new PR are part of this setup.
+2026-08-26: Snapshot mutable or unverifiable storage before Python callbacks can
+run. Preserve borrowing of immutable bytes-backed storage. Unknown read-only
+exporters remain accepted but their payloads retain an immutable snapshot.
 
-2026-08-26, Codex: Implement the plan after the user's instruction to proceed.
-Keep the failing exporter regression in `7883dad` and the ownership fixes in
-`2e61d8f` so their before-and-after behavior can be reproduced independently.
+2026-08-26: Add Python 3.9 to native CI because its synchronous garbage collection
+exercises a defect that newer interpreters did not reproduce. Intern the `obj`
+attribute name after measurements showed avoidable allocations.
 
-2026-08-26, Codex: Preserve borrowing of immutable bytes-backed storage. Snapshot
-mutable or unverifiable storage before Python callbacks, including unknown
-read-only exporters. This closes demonstrated defects without rejecting
-previously accepted valid exporters. Add Python 3.9 to native CI because the GC
-regression does not execute callbacks inside feed on newer interpreters.
+2026-08-26: Reopen this plan for the user's upstream publication request. The
+publishing account has read-only upstream access; project-label creation failed.
 
 ## Outcomes and Retrospective
 
 
-The independent branch contains deterministic Rust tests, Python buffer and
-lifetime tests, repeatable Miri and AddressSanitizer scripts, and CI definitions.
-The full Miri suite passed 188 tests. Six targeted configurations passed under
-two reference models and three execution seeds. AddressSanitizer detected the
-deliberate bad test library, then passed 47 tests on Python 3.9 (five unsupported
-Python-exporter cases skipped) and 52 tests on Python 3.13.
+Implementation and local validation are complete. Two Python ownership defects
+were fixed without adding production unsafe blocks. Scanner assertions are
+test/Miri-only. Bytearray input adds one snapshot allocation per chunk; measured
+immutable-input allocation counts are unchanged. Shared-host timings do not
+support a general speedup claim or a consistent slowdown.
 
-Two Python input ownership bugs were reproduced and fixed. No new production
-unsafe block was added. Scanner validation assertions run only in test or Miri
-builds. Python mutable-input snapshots add one allocation per chunk; the measured
-ordinary immutable-input allocation counts are unchanged. Shared-host timings
-did not show a consistent slowdown. Detailed results and limitations are in
-`record.md` and `docs/memory-safety-testing.md`.
-
-The existing PR and its checkout were not modified. This branch is based on
-upstream `47a5427` and can be reviewed independently. No new PR was opened or
-pushed. CI definitions passed actionlint and their test commands passed locally;
-hosted CI has not run for this branch.
+Upstream publication and final hosted checks remain. Local results and coverage
+limits are in `record.md`; passing tests are not proof of soundness.
 
 ## Context and Orientation
 
 
-Miri executes Rust tests while checking for certain invalid memory operations.
-It can detect a dangling pointer in a test that uses that pointer, but a green
-job does not prove every possible use is valid. Its Stacked Borrows and Tree
-Borrows models check rules governing overlapping references. Test both without
-disabling their checks; record the Rust nightly version because these tools
-change over time.
+The scanner's unchecked conversions require valid UTF-8. ValueZipper caches
+pointers into a boxed root, arrays, and ordered maps; old child pointers must be
+discarded before ancestor storage moves. Python buffer guards retain native
+storage, but read-only access does not establish immutable backing.
 
-The scanner builds strings from input batches and saved fragments. Four
-`from_utf8_unchecked` calls assume that the selected bytes form valid UTF-8.
-`ValueZipper` stores raw pointers to values inside a boxed root, vectors, and
-ordered maps. Pointers must remain valid when those containers grow or change.
-Its current traversal expects parser depth changes of one level at a time.
-
-The Python binding obtains buffer pointers with `PyObject_GetBuffer`, constructs
-Rust slices, and releases the buffer through `PyBufferGuard`. Other unsafe
-operations handle Python object references. Correctness depends on pointer
-validity, lengths, ownership, and object lifetimes. A native extension that lies
-about the allocation behind a pointer is a separate trust assumption; checking
-metadata alone cannot prove that arbitrary native memory exists.
-
-AddressSanitizer adds runtime checks to native code for errors such as reads
-beyond allocated memory and use after free. It complements Miri but does not
-check all Rust reference rules. An ordinary Python test run is neither test.
+Miri executes Rust tests and checks certain invalid memory operations and
+reference uses. Its Stacked Borrows and Tree Borrows models check overlapping
+references. AddressSanitizer instruments native access checks but does not
+check every Rust reference rule. CPython itself remains uninstrumented here.
 
 ## Plan of Work
 
 
-### 1. Record assumptions and establish the baseline
+The completed implementation adds test-only scanner assertions, dedicated
+ValueZipper tests, and plain integration assertions that do not depend on
+snapshot filesystem access. Python tests cover buffer release, retained views,
+input mutations, and the two confirmed callback defects.
 
-
-For every unsafe expression in the three primary files, record its function,
-operation, required assumptions, enforcing caller, and existing tests in
-`record.md`. Trace Python reference ownership and every buffer release on both
-success and error. Inspect parser call sequences before designing direct zipper
-tests; do not accidentally treat an impossible internal sequence as normal use.
-If a safe callable API permits such a sequence, determine whether it must reject
-it rather than relying on a debug-only assertion.
-
-Run the existing focused scanner tests, core checks, and Python tests. List which
-tests Miri actually executes. Record excluded crates and compiled-out tests
-separately from ignored tests. Preserve any baseline failure with its input and
-command before changing code.
-
-### 2. Exercise string construction and pointer lifetimes
-
-
-Extend `crates/jsonmodem/src/parser/scanner/tests.rs` with deterministic tests
-covering empty strings, ASCII, two- through four-byte Unicode characters,
-escapes, carried fragments, and borrowed-to-owned transitions. Exercise each
-unchecked conversion. In test or Miri builds, validate its input with
-`str::from_utf8` before the unchecked call, so a bad UTF-8 assumption fails
-explicitly. Test malformed bytes through APIs that accept bytes; Rust `&str`
-inputs must already be valid UTF-8. Do not create invalid Rust strings in tests.
-
-Add a private test module in `value_zipper.rs`. Force vector capacity growth and
-enough ordered-map insertions to exercise node growth. Follow valid parser
-sequences through descent, ascent, siblings, repeated keys, replacing a value,
-`with_leaf_mut`, `with_leaf`, and `take_root` followed by reuse. Assert complete
-values and paths, not just absence of a crash. Add parser-level tests for the
-same transitions so the direct tests do not stand alone.
-
-For a memory error, save a small failing test before fixing production code.
-Prefer removing an unnecessary unsafe operation or correcting pointer lifetime
-over a new general-purpose abstraction. Keep tests that detect invalid UTF-8 and
-pointer use out of release hot loops unless a runtime check is actually needed.
-
-### 3. Make Rust coverage reproducible under Miri
-
-
-Add `crates/jsonmodem/tests/memory_safety.rs` for deterministic streaming
-integration assertions. Share plain assertion helpers with the existing values
-and buffers tests where practical. Keep snapshot rendering separate so filesystem
-access by `insta` does not exclude the underlying behavior from Miri.
-
-Use a compact generated corpus with recorded seeds and exhaustive valid split
-positions for short inputs. Include values and buffers adapters, repeated roots,
-partial strings, early iterator drop, and parser error cleanup. Any byte split
-that the API intentionally rejects must assert that rejection rather than
-assuming arbitrary partial UTF-8 is accepted.
-
-Run targeted tests with Miri seeds 0, 1, and 2 under both Stacked Borrows and Tree
-Borrows. Retain the existing full Miri suite. Measure duration before setting CI
-timeouts. Provide an explicit configurable case count for generated tests, with
-the selected count printed in logs and passed into Miri's isolated environment.
-Do not silently reduce the new safety tests to ten cases or confuse Miri's
-execution seed with the generated-input seed.
-
-### 4. Check the Python extension as native code
-
-
-Add `crates/jsonmodem-py/tests/test_buffer_safety.py`. Exercise bytes, bytearray,
-read-only and writable memoryviews, empty buffers, slices, unsupported layouts,
-released views, invalid UTF-8, failed acquisition, and cleanup after exceptions.
-Hold events and payload views after discarding the input or parser. Test partial
-iterator consumption, repeated creation and destruction, and input mutation
-where the documented API permits it. Verify the intended ownership or rejection
-for each case.
-
-Add `.agent/check-py-memory.sh` using a separate virtual environment and Cargo
-target directory. First demonstrate a Linux AddressSanitizer build of the Rust
-extension with a matching native runtime. Verify activation using a temporary
-known-bad allocation test that must fail in a subprocess; never ship that code
-as part of the production extension. Then run the targeted and existing Python
-tests. Record compiler/runtime versions and whether CPython is instrumented.
-
-Use subprocesses with timeouts for tests that could terminate the interpreter.
-Exercise metadata rejection without dereferencing fabricated addresses. Do not
-claim support for malicious native exporters or change the accepted buffer types
-just to obtain a green job. If instrumentation cannot cover a required operation,
-record the exact limitation and resolve the test approach before marking this
-milestone complete. Any runtime fix must have its own before-and-after test.
-
-### 5. Put the checks in CI and document the result
-
-
-Update `.github/workflows/miri.yml` to execute the targeted tests in both models
-with the selected seeds, while retaining the broader suite. Make local Miri
-execution use consistent crate exclusions. Add
-`.github/workflows/python-memory.yml` to call the proven native test script.
-Document prerequisites in `.agent/setup.sh` or `.agent/setup-py.sh` and `AGENTS.md`
-where needed. Do not add a job that passes after silently skipping instrumentation.
-
-Document commands, covered assumptions, and remaining limitations in
-`docs/memory-safety-testing.md`. Record the final test names and results in
-`record.md`. Review the diff against the recorded upstream base. If source
-changes affect streaming performance, compare the existing streaming benchmark
-before and after on the same machine and record timings and allocation changes.
-Do not use one-shot orjson throughput as this branch's performance target.
+`.agent/check-miri.sh` runs the existing full suite and targeted configurations.
+`.agent/check-py-memory.sh` builds a launcher and extension using the same Rust
+sanitizer runtime, verifies an expected failure, and runs Python tests. CI calls
+these scripts. Publication must retain this test coverage and its limitations.
 
 ## Concrete Steps
 
 
-Run commands from the new jsonmodem worktree. Initial checks use existing files:
+Run from this worktree:
 
-    cargo test -p jsonmodem --lib parser::scanner::tests
     .agent/check.sh
     .agent/setup-py.sh
     .agent/check-py.sh
-    cargo +nightly miri setup
-    cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+    cargo clippy -p jsonmodem-py -- -D warnings
+    cargo test -p jsonmodem --release --lib memory_safety
+    cargo test -p jsonmodem --release --test memory_safety
+    bash .agent/check-miri.sh
+    JSONMODEM_MEMORY_PYTHON=3.9 bash .agent/check-py-memory.sh
+    JSONMODEM_MEMORY_PYTHON=3.13 bash .agent/check-py-memory.sh
 
-After adding the tests, the fastest checks are:
-
-    cargo test -p jsonmodem --lib value_zipper
-    cargo test -p jsonmodem --test memory_safety
-    cargo +nightly miri test -p jsonmodem --lib value_zipper
-    MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-seed=0" cargo +nightly miri test -p jsonmodem --test memory_safety
-
-Repeat targeted Miri commands for both models and all three selected seeds. The
-default model uses `-Zmiri-seed=0` without `-Zmiri-tree-borrows`. Set the generated
-case count with `-Zmiri-env-set=JSONMODEM_SAFETY_CASES=32`.
-`bash .agent/check-miri.sh` runs the full suite and all targeted configurations.
-
-After adding and verifying the native script, run:
-
-    bash .agent/check-py-memory.sh
-
-The native script now builds a Rust launcher and extension with the same
-AddressSanitizer runtime. It checks a deliberate failure, verifies the installed
-extension, and runs Python tests. Set `JSONMODEM_MEMORY_PYTHON=3.9` or `3.13` to
-reproduce the two tested interpreter versions. See the record for tool versions.
+The fastest Rust checks are `cargo test -p jsonmodem --lib memory_safety` and
+`cargo test -p jsonmodem --test memory_safety`. The native script requires Linux
+x86_64 and a shared libpython. Tool prerequisites are documented in `AGENTS.md`.
 
 ## Validation and Acceptance
 
 
-Fast checks are the focused tests above. Final validation includes
-`.agent/check.sh`, `.agent/check-py.sh`, the full existing Miri suite, the new
-targeted Miri runs, and the Python native memory checks. Add a release-mode run of
-the Rust safety tests so debug assertions do not conceal reliance on missing
-runtime validation. All must exit successfully with no unexplained diagnostic.
-
-For a coverage-only test, demonstrate that it executes its intended operation
-and asserts the relevant result. For a production bug, demonstrate a failing
-baseline and passing fix. Where practical, temporarily inject a narrowly scoped
-fault to show the new check catches it, then remove that fault and record the
-result. Do not put deliberate undefined behavior in the normal test suite.
-
-Final review checks every unsafe assumption against its named test and clearly
-lists untested cases. A reviewer must be able to reproduce each result from the
-recorded commit and commands. More passing tests alone do not meet acceptance.
+All commands must pass without unexplained diagnostics. Keep the deliberate
+sanitizer failure in its isolated subprocess; it is required evidence that
+instrumentation works. Distinguish excluded crates, compiled-out tests, ignored
+tests, and actual execution. Preserve baseline failures for production fixes.
+After publication, inspect checks for the exact published head before marking
+the PR ready. Do not bypass approvals or classify missing checks as passing.
 
 ## Idempotence and Recovery
 
 
-Use this worktree's own Python environment and target directory. Do not rebuild
-into PR #1's environment or reset its checkout. Keep fault injection and crash
-artifacts in disposable locations. Repeat a failed command only after recording
-whether the failure came from the test, setup, or unsupported instrumentation.
-Do not suppress a memory error, disable reference checks, or increase a timeout
-without recording why. Do not force-push or modify someone else's branch.
-
-## Artifacts and Notes
-
-
-`record.md` starts with baseline facts and then records each test attempt before
-it runs: question, assumptions, input, method, expected evidence, and decision
-rule. Afterward add the commit, exact command, tool versions, result, limitation,
-and next action. Keep full transcripts outside Git and retain compact summaries.
+Use this worktree's environments and target directories. Do not reset another
+checkout or force-push. Keep full artifacts outside Git. For a failing command,
+record whether the cause is a test failure, tool setup, or missing permission.
+Do not suppress a memory error or disable reference checks to obtain a pass.
 
 ## Interfaces and Dependencies
 
 
-Keep the public Rust and Python interfaces unchanged unless a reproduced defect
-requires a documented correction. Use existing Rust tests, `pytest`, PyO3,
-Miri, and the native compiler's AddressSanitizer. Additional tools belong only in
-development or CI setup. Do not add another parsing backend or depend on the
-orjson frontend from PR #1.
+Public Rust and Python entry points remain unchanged. Valid external exporters
+are still accepted, with snapshots where immutability cannot be established.
+Use existing PyO3, pytest, Miri, and native compiler tooling. Memray and pyperf
+are development-only dependencies for the buffer comparison benchmark.
+
+## Artifacts and Notes
+
+
+`record.md` retains the source commits, reproducer results, validation commands,
+timing and allocation tables, and publication status. Generated wheels, logs,
+and allocator traces are not part of the upstream diff.
 
 ## Next Action
 
 
-No implementation work remains. If publication is requested, push this branch
-to the user's fork and open a separate draft PR based on upstream main. Verify
-the hosted checks before marking that PR ready. Do not merge it or modify PR #1.
-
-Created 2026-08-26 to address missing memory-safety test coverage independently
-of the orjson frontend PR.
-
-Completed 2026-08-26 after actual Miri/native execution, two reproduced Python
-defects and fixes, allocation measurements, and review. Publication remains a
-separate user decision.
+Push the branch to the user's fork and create the upstream draft PR. Check
+whether fork workflows need maintainer approval, then verify required checks.

--- a/plans/memory-safety-tests/plan.md
+++ b/plans/memory-safety-tests/plan.md
@@ -1,7 +1,8 @@
 # Test unsafe streaming code and Python buffers
 
 
-Status: upstream PR #74 is open; CI awaits maintainer approval (2026-08-26).
+Status: upstream PR #74 is ready for review at the user's request; hosted
+validation awaits maintainer approval (2026-08-26).
 This plan follows `PLANS.md`. Keep Progress, Decision Log, and Outcomes current
 until the upstream PR's final checks pass.
 
@@ -47,7 +48,8 @@ confirmed defect has a failing baseline and a passing regression after the fix.
 
 Existing tests pass. Performance and allocation changes are measured. The
 separate upstream PR is labeled `jsonmodem` if repository permissions allow it,
-and becomes ready for review after required checks pass on its final head.
+and required checks pass on its final head. The user explicitly requested ready
+status before those checks could run; preserve that status.
 Document any permission limitation rather than bypassing repository controls.
 No merge is authorized.
 
@@ -64,7 +66,8 @@ No merge is authorized.
 - [x] (2026-08-26) Refresh upstream once; confirm the base remains `47a5427` and no matching PR exists.
 - [x] (2026-08-26) Push the branch and create upstream draft PR #74.
 - [x] (2026-08-26) Record the project-label permission limitation; the publishing account cannot create the missing label.
-- [ ] Verify final hosted checks and mark the PR ready.
+- [x] (2026-08-26) Mark PR #74 ready for review at the user's explicit request.
+- [ ] Verify required hosted checks on the final published head after maintainer approval.
 
 ## Surprises and Discoveries
 
@@ -101,6 +104,10 @@ attribute name after measurements showed avoidable allocations.
 2026-08-26: Reopen this plan for the user's upstream publication request. The
 publishing account has read-only upstream access; project-label creation failed.
 
+2026-08-26: The user requested ready status while fork workflows await approval.
+Mark PR #74 ready without changing CI requirements. Do not return it to draft
+without the user's permission. Readiness does not establish successful testing.
+
 ## Outcomes and Retrospective
 
 
@@ -110,10 +117,10 @@ test/Miri-only. Bytearray input adds one snapshot allocation per chunk; measured
 immutable-input allocation counts are unchanged. Shared-host timings do not
 support a general speedup claim or a consistent slowdown.
 
-[Upstream PR #74](https://github.com/AaronFriel/jsonmodem/pull/74) is open as a
-draft and is mergeable. All ten workflow runs require maintainer approval before
-executing fork code. The publishing account cannot approve them or create the
-missing project label. Final hosted checks and marking the PR ready remain.
+[Upstream PR #74](https://github.com/AaronFriel/jsonmodem/pull/74) is ready for
+review at the user's request. All ten workflow runs require maintainer approval
+before executing fork code. The publishing account cannot approve them or create
+the missing project label. Final hosted validation remains incomplete.
 Local results and coverage limits are in `record.md`; passing tests are not proof
 of soundness.
 
@@ -169,8 +176,9 @@ All commands must pass without unexplained diagnostics. Keep the deliberate
 sanitizer failure in its isolated subprocess; it is required evidence that
 instrumentation works. Distinguish excluded crates, compiled-out tests, ignored
 tests, and actual execution. Preserve baseline failures for production fixes.
-After publication, inspect checks for the exact published head before marking
-the PR ready. Do not bypass approvals or classify missing checks as passing.
+After publication, inspect checks for the exact published head before completing
+this plan. The PR is already ready at the user's request. Do not bypass approvals
+or classify ready status or missing checks as passing CI.
 
 ## Idempotence and Recovery
 
@@ -199,6 +207,11 @@ and allocator traces are not part of the upstream diff.
 
 
 A maintainer must approve the fork workflows on PR #74 and apply the `jsonmodem`
-label. After approval, inspect the runs for the current PR head, address in-scope
-failures, and mark the PR ready only after required checks pass. Do not bypass
-approval or treat an empty check list as passing CI.
+label. After approval, inspect the runs for the current PR head and address
+in-scope failures. Preserve ready status and complete this plan only after
+required checks pass. Do not bypass approval or treat an empty check list as
+passing CI.
+
+Revision (2026-08-26): Record the user's request for ready status separately from
+the still-incomplete hosted validation, so review status cannot be mistaken for
+test evidence.

--- a/plans/memory-safety-tests/plan.md
+++ b/plans/memory-safety-tests/plan.md
@@ -1,0 +1,355 @@
+# Test unsafe streaming code and Python buffers
+
+
+Status: active on 2026-08-26. Implementation is underway. This plan follows
+`PLANS.md` and uses `plan.md` and `record.md` as requested. Keep Progress,
+Surprises and Discoveries, Decision Log, and Outcomes and Retrospective current.
+
+## Purpose / Big Picture
+
+
+Make the memory-safety checks for jsonmodem's streaming parser and Python binding
+specific and reproducible. Today, a passing Miri job says little about the Python
+binding because that crate is excluded. Some Rust integration tests are also
+excluded, and the pointer traversal has no dedicated unit tests.
+
+After this work, contributors will have tests tied to the assumptions behind
+each relevant `unsafe` block, a Miri command for the Rust tests, and a native
+memory-checking command for the Python extension. Confirmed defects will have
+regression tests and fixes. Passing these checks will not be described as proof
+that all possible inputs and Python objects are safe.
+
+## Plan Layout
+
+
+`plans/memory-safety-tests/plan.md` owns scope, decisions, and completion status.
+`plans/memory-safety-tests/record.md` holds the safety assumptions, named tests,
+commands, results, and remaining omissions. Follow the existing repository
+convention of storing plans under `plans/<task>/`.
+
+Keep only compact, public evidence in these files. Put build products, full logs,
+generated corpora, and temporary fault-injection programs outside tracked files.
+Before publication, summarize the record and review the diff. No merge is
+authorized by this plan; this cleanup rule applies regardless of merge method.
+
+## Work Boundaries
+
+
+Use branch `dev/friel/memory-safety-tests` in the separate worktree created from
+`upstream/main` at `47a542760f84dd402cecda6476b56dc92dae54e5`. Do not merge or
+cherry-pick the orjson frontend PR to obtain these changes. The base repository
+is `AaronFriel/jsonmodem`; the user's publishing fork is `friel-openai/jsonmodem`.
+
+The primary files are `crates/jsonmodem/src/parser/scanner/mod.rs`, its
+`tests.rs`, `crates/jsonmodem/src/backend/std/value_zipper.rs`, and
+`crates/jsonmodem-py/src/lib.rs`. Related Rust integration tests, Python tests,
+`.github/workflows/miri.yml`, `.config/nextest.toml`, and `.agent/` test scripts
+are in scope. Follow callers into `parser/mod.rs` and `value_applicator.rs` when
+needed to establish a safety assumption. Do not turn this into a repository-wide
+rewrite or add runtime dependencies for test infrastructure.
+
+Preserve streaming events, partial values, supported buffer inputs, and normal
+performance. Start with tests and test-only assertions. Change production code
+only for a demonstrated defect or a necessary clarification of an unsafe
+operation's preconditions. Record and measure any runtime change.
+
+PR #1 and its active `plans/orjson-security-audit/plan.md` remain separate. That
+audit concerns the frontend and changes made by PR #1; this plan concerns
+upstream streaming code and repeatable memory-safety testing. Do not edit that
+checkout or its plans. If both efforts discover the same defect, coordinate
+which branch owns the fix before publishing duplicate changes. Do not copy
+private source, usage details, payloads, project information, or communications
+into this repository. All test inputs must be synthetic or already public.
+
+## Definition of Done
+
+
+Each explicit unsafe operation in the three primary source files has a recorded
+safety assumption, an explanation of how callers enforce it, and named tests
+that exercise it. Any assumption that cannot be tested is listed as a limitation.
+The record distinguishes source inspection, actual Miri execution, and native
+sanitizer execution. It does not infer coverage from compilation or test totals.
+
+Scanner tests check valid UTF-8 at every unchecked conversion in test builds.
+Dedicated ValueZipper tests exercise allocation growth, sibling changes,
+replacement, and root reuse. Relevant behavior currently hidden behind snapshot
+test exclusions has plain assertions that run under Miri. The tests run with
+both reference-aliasing models described below and recorded deterministic seeds.
+
+Python buffer and object-lifetime tests run against an instrumented extension.
+A temporary known-bad program confirms that the native memory checker is active.
+The record states whether CPython itself is instrumented and what remains
+outside detection. There must be no unexplained memory-checking reports.
+
+Existing Rust and Python tests still pass. Every confirmed production defect has
+a minimal reproducer that fails before its fix and passes after. A separate PR,
+when publication is requested, must contain no dependency on PR #1 and have all
+required checks green before it is marked ready. Do not merge either PR.
+
+## Progress
+
+
+- [x] (2026-08-26 05:26Z) Inspect upstream, the Miri workflow, test exclusions, and buffer handling.
+- [x] (2026-08-26 05:26Z) Create an independent worktree and branch at upstream `47a5427`.
+- [x] (2026-08-26 05:26Z) Write this plan and the initial evidence record.
+- [x] (2026-08-26) Map each unsafe operation to its safety assumptions and named tests; document untested cases.
+- [x] (2026-08-26) Add six scanner/ValueZipper unit tests and four integration tests. No production defect reproduced so far.
+- [ ] Finish all six targeted Miri configurations and the full suite (completed: default model seeds 0 and 1; remaining: other seeds/model and full-suite completion).
+- [x] (2026-08-26) Verify native instrumentation with a required failure check; pass 50 Python tests on CPython 3.12.
+- [x] (2026-08-26) Add CI commands, local scripts, prerequisites, and coverage documentation.
+- [ ] Run final checks, review the independent diff, and summarize results.
+
+## Surprises and Discoveries
+
+
+The upstream Miri workflow already excludes `jsonmodem-py` and
+`jsonmodem-fuzz`. The exclusions do not depend on PR #1. ValueZipper is unchanged
+between upstream and PR #1. The scanner has a numeric accumulation fix in PR #1,
+but its unchecked UTF-8 conversions and existing tests are already upstream.
+
+The repository's `.agent/check.sh` compiles a Clippy configuration with
+`cfg(miri)`, but skips actual Miri execution by default. The optional Miri command
+also differs from the workflow's crate exclusions. Neither compilation nor a
+skipped command is execution evidence.
+
+## Decision Log
+
+
+2026-08-26, Codex: Base the work on upstream `47a5427`, not PR #1. All three
+reviewed areas exist upstream, so adding safety tests does not require the
+orjson-compatible API. This permits independent review and merging.
+
+2026-08-26, Codex: Keep one plan with separate Rust and Python milestones.
+Miri interprets Rust operations; the existing CPython calls need a separate
+native test arrangement. Removing the Python exclusion without addressing those
+calls would not establish coverage.
+
+2026-08-26, Codex: Prepare the plan and worktree now. Implementation and
+publication remain unchecked; no source edits or new PR are part of this setup.
+
+## Outcomes and Retrospective
+
+
+The independent worktree now contains deterministic Rust tests, Python buffer
+and lifetime tests, Miri and AddressSanitizer scripts, and CI jobs. Native
+instrumentation has been verified by a deliberate failure, and 50 Python tests
+pass on CPython 3.12. Final Miri validation and review are still running. The
+existing PR and its uncommitted audit work were left untouched.
+
+## Context and Orientation
+
+
+Miri executes Rust tests while checking for certain invalid memory operations.
+It can detect a dangling pointer in a test that uses that pointer, but a green
+job does not prove every possible use is valid. Its Stacked Borrows and Tree
+Borrows models check rules governing overlapping references. Test both without
+disabling their checks; record the Rust nightly version because these tools
+change over time.
+
+The scanner builds strings from input batches and saved fragments. Four
+`from_utf8_unchecked` calls assume that the selected bytes form valid UTF-8.
+`ValueZipper` stores raw pointers to values inside a boxed root, vectors, and
+ordered maps. Pointers must remain valid when those containers grow or change.
+Its current traversal expects parser depth changes of one level at a time.
+
+The Python binding obtains buffer pointers with `PyObject_GetBuffer`, constructs
+Rust slices, and releases the buffer through `PyBufferGuard`. Other unsafe
+operations handle Python object references. Correctness depends on pointer
+validity, lengths, ownership, and object lifetimes. A native extension that lies
+about the allocation behind a pointer is a separate trust assumption; checking
+metadata alone cannot prove that arbitrary native memory exists.
+
+AddressSanitizer adds runtime checks to native code for errors such as reads
+beyond allocated memory and use after free. It complements Miri but does not
+check all Rust reference rules. An ordinary Python test run is neither test.
+
+## Plan of Work
+
+
+### 1. Record assumptions and establish the baseline
+
+
+For every unsafe expression in the three primary files, record its function,
+operation, required assumptions, enforcing caller, and existing tests in
+`record.md`. Trace Python reference ownership and every buffer release on both
+success and error. Inspect parser call sequences before designing direct zipper
+tests; do not accidentally treat an impossible internal sequence as normal use.
+If a safe callable API permits such a sequence, determine whether it must reject
+it rather than relying on a debug-only assertion.
+
+Run the existing focused scanner tests, core checks, and Python tests. List which
+tests Miri actually executes. Record excluded crates and compiled-out tests
+separately from ignored tests. Preserve any baseline failure with its input and
+command before changing code.
+
+### 2. Exercise string construction and pointer lifetimes
+
+
+Extend `crates/jsonmodem/src/parser/scanner/tests.rs` with deterministic tests
+covering empty strings, ASCII, two- through four-byte Unicode characters,
+escapes, carried fragments, and borrowed-to-owned transitions. Exercise each
+unchecked conversion. In test or Miri builds, validate its input with
+`str::from_utf8` before the unchecked call, so a bad UTF-8 assumption fails
+explicitly. Test malformed bytes through APIs that accept bytes; Rust `&str`
+inputs must already be valid UTF-8. Do not create invalid Rust strings in tests.
+
+Add a private test module in `value_zipper.rs`. Force vector capacity growth and
+enough ordered-map insertions to exercise node growth. Follow valid parser
+sequences through descent, ascent, siblings, repeated keys, replacing a value,
+`with_leaf_mut`, `with_leaf`, and `take_root` followed by reuse. Assert complete
+values and paths, not just absence of a crash. Add parser-level tests for the
+same transitions so the direct tests do not stand alone.
+
+For a memory error, save a small failing test before fixing production code.
+Prefer removing an unnecessary unsafe operation or correcting pointer lifetime
+over a new general-purpose abstraction. Keep tests that detect invalid UTF-8 and
+pointer use out of release hot loops unless a runtime check is actually needed.
+
+### 3. Make Rust coverage reproducible under Miri
+
+
+Add `crates/jsonmodem/tests/memory_safety.rs` for deterministic streaming
+integration assertions. Share plain assertion helpers with the existing values
+and buffers tests where practical. Keep snapshot rendering separate so filesystem
+access by `insta` does not exclude the underlying behavior from Miri.
+
+Use a compact generated corpus with recorded seeds and exhaustive valid split
+positions for short inputs. Include values and buffers adapters, repeated roots,
+partial strings, early iterator drop, and parser error cleanup. Any byte split
+that the API intentionally rejects must assert that rejection rather than
+assuming arbitrary partial UTF-8 is accepted.
+
+Run targeted tests with Miri seeds 0, 1, and 2 under both Stacked Borrows and Tree
+Borrows. Retain the existing full Miri suite. Measure duration before setting CI
+timeouts. Provide an explicit configurable case count for generated tests, with
+the selected count printed in logs and passed into Miri's isolated environment.
+Do not silently reduce the new safety tests to ten cases or confuse Miri's
+execution seed with the generated-input seed.
+
+### 4. Check the Python extension as native code
+
+
+Add `crates/jsonmodem-py/tests/test_buffer_safety.py`. Exercise bytes, bytearray,
+read-only and writable memoryviews, empty buffers, slices, unsupported layouts,
+released views, invalid UTF-8, failed acquisition, and cleanup after exceptions.
+Hold events and payload views after discarding the input or parser. Test partial
+iterator consumption, repeated creation and destruction, and input mutation
+where the documented API permits it. Verify the intended ownership or rejection
+for each case.
+
+Add `.agent/check-py-memory.sh` using a separate virtual environment and Cargo
+target directory. First demonstrate a Linux AddressSanitizer build of the Rust
+extension with a matching native runtime. Verify activation using a temporary
+known-bad allocation test that must fail in a subprocess; never ship that code
+as part of the production extension. Then run the targeted and existing Python
+tests. Record compiler/runtime versions and whether CPython is instrumented.
+
+Use subprocesses with timeouts for tests that could terminate the interpreter.
+Exercise metadata rejection without dereferencing fabricated addresses. Do not
+claim support for malicious native exporters or change the accepted buffer types
+just to obtain a green job. If instrumentation cannot cover a required operation,
+record the exact limitation and resolve the test approach before marking this
+milestone complete. Any runtime fix must have its own before-and-after test.
+
+### 5. Put the checks in CI and document the result
+
+
+Update `.github/workflows/miri.yml` to execute the targeted tests in both models
+with the selected seeds, while retaining the broader suite. Make local Miri
+execution use consistent crate exclusions. Add
+`.github/workflows/python-memory.yml` to call the proven native test script.
+Document prerequisites in `.agent/setup.sh` or `.agent/setup-py.sh` and `AGENTS.md`
+where needed. Do not add a job that passes after silently skipping instrumentation.
+
+Document commands, covered assumptions, and remaining limitations in
+`docs/memory-safety-testing.md`. Record the final test names and results in
+`record.md`. Review the diff against the recorded upstream base. If source
+changes affect streaming performance, compare the existing streaming benchmark
+before and after on the same machine and record timings and allocation changes.
+Do not use one-shot orjson throughput as this branch's performance target.
+
+## Concrete Steps
+
+
+Run commands from the new jsonmodem worktree. Initial checks use existing files:
+
+    cargo test -p jsonmodem --lib parser::scanner::tests
+    .agent/check.sh
+    .agent/setup-py.sh
+    .agent/check-py.sh
+    cargo +nightly miri setup
+    cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+
+After adding the tests, the fastest checks are:
+
+    cargo test -p jsonmodem --lib value_zipper
+    cargo test -p jsonmodem --test memory_safety
+    cargo +nightly miri test -p jsonmodem --lib value_zipper
+    MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-seed=0" cargo +nightly miri test -p jsonmodem --test memory_safety
+
+Repeat targeted Miri commands for both models and all three selected seeds. The
+default model uses `-Zmiri-seed=0` without `-Zmiri-tree-borrows`. For any configurable
+test count, use `-Zmiri-env-set=NAME=VALUE` with the actual name added by the tests.
+Write the final full commands in the record; this placeholder is not evidence.
+
+After adding and verifying the native script, run:
+
+    .agent/check-py-memory.sh
+
+No sanitizer build recipe is claimed to work yet. Milestone 4 must establish and
+record the exact build command, runtime loading, interpreter, and failure check.
+
+## Validation and Acceptance
+
+
+Fast checks are the focused tests above. Final validation includes
+`.agent/check.sh`, `.agent/check-py.sh`, the full existing Miri suite, the new
+targeted Miri runs, and the Python native memory checks. Add a release-mode run of
+the Rust safety tests so debug assertions do not conceal reliance on missing
+runtime validation. All must exit successfully with no unexplained diagnostic.
+
+For a coverage-only test, demonstrate that it executes its intended operation
+and asserts the relevant result. For a production bug, demonstrate a failing
+baseline and passing fix. Where practical, temporarily inject a narrowly scoped
+fault to show the new check catches it, then remove that fault and record the
+result. Do not put deliberate undefined behavior in the normal test suite.
+
+Final review checks every unsafe assumption against its named test and clearly
+lists untested cases. A reviewer must be able to reproduce each result from the
+recorded commit and commands. More passing tests alone do not meet acceptance.
+
+## Idempotence and Recovery
+
+
+Use this worktree's own Python environment and target directory. Do not rebuild
+into PR #1's environment or reset its checkout. Keep fault injection and crash
+artifacts in disposable locations. Repeat a failed command only after recording
+whether the failure came from the test, setup, or unsupported instrumentation.
+Do not suppress a memory error, disable reference checks, or increase a timeout
+without recording why. Do not force-push or modify someone else's branch.
+
+## Artifacts and Notes
+
+
+`record.md` starts with baseline facts and then records each test attempt before
+it runs: question, assumptions, input, method, expected evidence, and decision
+rule. Afterward add the commit, exact command, tool versions, result, limitation,
+and next action. Keep full transcripts outside Git and retain compact summaries.
+
+## Interfaces and Dependencies
+
+
+Keep the public Rust and Python interfaces unchanged unless a reproduced defect
+requires a documented correction. Use existing Rust tests, `pytest`, PyO3,
+Miri, and the native compiler's AddressSanitizer. Additional tools belong only in
+development or CI setup. Do not add another parsing backend or depend on the
+orjson frontend from PR #1.
+
+## Next Action
+
+
+Finish the remaining Miri runs, check the Python sanitizer script on CPython
+3.13 to match CI, resolve concrete review findings, and record final validation.
+
+Created 2026-08-26 to address missing memory-safety test coverage independently
+of the orjson frontend PR.

--- a/plans/memory-safety-tests/plan.md
+++ b/plans/memory-safety-tests/plan.md
@@ -1,7 +1,7 @@
 # Test unsafe streaming code and Python buffers
 
 
-Status: active on 2026-08-26. Implementation is underway. This plan follows
+Status: completed locally on 2026-08-26. Publication was not requested. This plan follows
 `PLANS.md` and uses `plan.md` and `record.md` as requested. Keep Progress,
 Surprises and Discoveries, Decision Log, and Outcomes and Retrospective current.
 
@@ -9,9 +9,9 @@ Surprises and Discoveries, Decision Log, and Outcomes and Retrospective current.
 
 
 Make the memory-safety checks for jsonmodem's streaming parser and Python binding
-specific and reproducible. Today, a passing Miri job says little about the Python
-binding because that crate is excluded. Some Rust integration tests are also
-excluded, and the pointer traversal has no dedicated unit tests.
+specific and reproducible. Before this work, a passing Miri job said little about
+the Python binding because that crate was excluded. Some Rust integration tests
+were also excluded, and the pointer traversal had no dedicated unit tests.
 
 After this work, contributors will have tests tied to the assumptions behind
 each relevant `unsafe` block, a Miri command for the Rust tests, and a native
@@ -93,11 +93,13 @@ required checks green before it is marked ready. Do not merge either PR.
 - [x] (2026-08-26 05:26Z) Create an independent worktree and branch at upstream `47a5427`.
 - [x] (2026-08-26 05:26Z) Write this plan and the initial evidence record.
 - [x] (2026-08-26) Map each unsafe operation to its safety assumptions and named tests; document untested cases.
-- [x] (2026-08-26) Add six scanner/ValueZipper unit tests and four integration tests. No production defect reproduced so far.
-- [ ] Finish all six targeted Miri configurations and the full suite (completed: default model seeds 0 and 1; remaining: other seeds/model and full-suite completion).
-- [x] (2026-08-26) Verify native instrumentation with a required failure check; pass 50 Python tests on CPython 3.12.
+- [x] (2026-08-26) Add six scanner/ValueZipper unit tests and four integration tests.
+- [x] (2026-08-26) Pass 188 full-suite Miri tests and all six targeted configurations, each with 32 generated cases.
+- [x] (2026-08-26) Reproduce and fix exporter reacquisition and Python 3.9 GC mutation of borrowed input.
+- [x] (2026-08-26) Verify native instrumentation with a required failure check; pass 47 Python 3.9 tests and 52 Python 3.13 tests.
 - [x] (2026-08-26) Add CI commands, local scripts, prerequisites, and coverage documentation.
-- [ ] Run final checks, review the independent diff, and summarize results.
+- [x] (2026-08-26) Measure paired streaming timings and Memray allocations; remove avoidable attribute-name allocations.
+- [x] (2026-08-26) Pass final local checks and independent source review; commit fixes at `2e61d8f` without PR #1 ancestry.
 
 ## Surprises and Discoveries
 
@@ -111,6 +113,12 @@ The repository's `.agent/check.sh` compiles a Clippy configuration with
 `cfg(miri)`, but skips actual Miri execution by default. The optional Miri command
 also differs from the workflow's crate exclusions. Neither compilation nor a
 skipped command is execution evidence.
+
+The new Python tests and review found two real defects. Byte-view mode acquired
+different exports for parsing and payload creation. On Python 3.9, synchronous GC
+callbacks could mutate ordinary bytearray input during parsing. Both now have
+before-and-after regression evidence in `record.md`. They also show why passing
+Miri or AddressSanitizer alone would not establish input ownership correctness.
 
 ## Decision Log
 
@@ -127,14 +135,37 @@ calls would not establish coverage.
 2026-08-26, Codex: Prepare the plan and worktree now. Implementation and
 publication remain unchecked; no source edits or new PR are part of this setup.
 
+2026-08-26, Codex: Implement the plan after the user's instruction to proceed.
+Keep the failing exporter regression in `7883dad` and the ownership fixes in
+`2e61d8f` so their before-and-after behavior can be reproduced independently.
+
+2026-08-26, Codex: Preserve borrowing of immutable bytes-backed storage. Snapshot
+mutable or unverifiable storage before Python callbacks, including unknown
+read-only exporters. This closes demonstrated defects without rejecting
+previously accepted valid exporters. Add Python 3.9 to native CI because the GC
+regression does not execute callbacks inside feed on newer interpreters.
+
 ## Outcomes and Retrospective
 
 
-The independent worktree now contains deterministic Rust tests, Python buffer
-and lifetime tests, Miri and AddressSanitizer scripts, and CI jobs. Native
-instrumentation has been verified by a deliberate failure, and 50 Python tests
-pass on CPython 3.12. Final Miri validation and review are still running. The
-existing PR and its uncommitted audit work were left untouched.
+The independent branch contains deterministic Rust tests, Python buffer and
+lifetime tests, repeatable Miri and AddressSanitizer scripts, and CI definitions.
+The full Miri suite passed 188 tests. Six targeted configurations passed under
+two reference models and three execution seeds. AddressSanitizer detected the
+deliberate bad test library, then passed 47 tests on Python 3.9 (five unsupported
+Python-exporter cases skipped) and 52 tests on Python 3.13.
+
+Two Python input ownership bugs were reproduced and fixed. No new production
+unsafe block was added. Scanner validation assertions run only in test or Miri
+builds. Python mutable-input snapshots add one allocation per chunk; the measured
+ordinary immutable-input allocation counts are unchanged. Shared-host timings
+did not show a consistent slowdown. Detailed results and limitations are in
+`record.md` and `docs/memory-safety-testing.md`.
+
+The existing PR and its checkout were not modified. This branch is based on
+upstream `47a5427` and can be reviewed independently. No new PR was opened or
+pushed. CI definitions passed actionlint and their test commands passed locally;
+hosted CI has not run for this branch.
 
 ## Context and Orientation
 
@@ -288,16 +319,18 @@ After adding the tests, the fastest checks are:
     MIRIFLAGS="-Zmiri-tree-borrows -Zmiri-seed=0" cargo +nightly miri test -p jsonmodem --test memory_safety
 
 Repeat targeted Miri commands for both models and all three selected seeds. The
-default model uses `-Zmiri-seed=0` without `-Zmiri-tree-borrows`. For any configurable
-test count, use `-Zmiri-env-set=NAME=VALUE` with the actual name added by the tests.
-Write the final full commands in the record; this placeholder is not evidence.
+default model uses `-Zmiri-seed=0` without `-Zmiri-tree-borrows`. Set the generated
+case count with `-Zmiri-env-set=JSONMODEM_SAFETY_CASES=32`.
+`bash .agent/check-miri.sh` runs the full suite and all targeted configurations.
 
 After adding and verifying the native script, run:
 
-    .agent/check-py-memory.sh
+    bash .agent/check-py-memory.sh
 
-No sanitizer build recipe is claimed to work yet. Milestone 4 must establish and
-record the exact build command, runtime loading, interpreter, and failure check.
+The native script now builds a Rust launcher and extension with the same
+AddressSanitizer runtime. It checks a deliberate failure, verifies the installed
+extension, and runs Python tests. Set `JSONMODEM_MEMORY_PYTHON=3.9` or `3.13` to
+reproduce the two tested interpreter versions. See the record for tool versions.
 
 ## Validation and Acceptance
 
@@ -348,8 +381,13 @@ orjson frontend from PR #1.
 ## Next Action
 
 
-Finish the remaining Miri runs, check the Python sanitizer script on CPython
-3.13 to match CI, resolve concrete review findings, and record final validation.
+No implementation work remains. If publication is requested, push this branch
+to the user's fork and open a separate draft PR based on upstream main. Verify
+the hosted checks before marking that PR ready. Do not merge it or modify PR #1.
 
 Created 2026-08-26 to address missing memory-safety test coverage independently
 of the orjson frontend PR.
+
+Completed 2026-08-26 after actual Miri/native execution, two reproduced Python
+defects and fixes, allocation measurements, and review. Publication remains a
+separate user decision.

--- a/plans/memory-safety-tests/plan.md
+++ b/plans/memory-safety-tests/plan.md
@@ -1,7 +1,7 @@
 # Test unsafe streaming code and Python buffers
 
 
-Status: implementation complete; upstream publication in progress (2026-08-26).
+Status: upstream PR #74 is open; CI awaits maintainer approval (2026-08-26).
 This plan follows `PLANS.md`. Keep Progress, Decision Log, and Outcomes current
 until the upstream PR's final checks pass.
 
@@ -62,8 +62,8 @@ No merge is authorized.
 - [x] (2026-08-26) Measure streaming time and allocations; remove per-chunk attribute-name allocations.
 - [x] (2026-08-26) Complete local checks and independent source review.
 - [x] (2026-08-26) Refresh upstream once; confirm the base remains `47a5427` and no matching PR exists.
-- [ ] Push the branch and create the upstream draft PR.
-- [ ] Apply the project label, or record the upstream permission limitation.
+- [x] (2026-08-26) Push the branch and create upstream draft PR #74.
+- [x] (2026-08-26) Record the project-label permission limitation; the publishing account cannot create the missing label.
 - [ ] Verify final hosted checks and mark the PR ready.
 
 ## Surprises and Discoveries
@@ -110,8 +110,12 @@ test/Miri-only. Bytearray input adds one snapshot allocation per chunk; measured
 immutable-input allocation counts are unchanged. Shared-host timings do not
 support a general speedup claim or a consistent slowdown.
 
-Upstream publication and final hosted checks remain. Local results and coverage
-limits are in `record.md`; passing tests are not proof of soundness.
+[Upstream PR #74](https://github.com/AaronFriel/jsonmodem/pull/74) is open as a
+draft and is mergeable. All ten workflow runs require maintainer approval before
+executing fork code. The publishing account cannot approve them or create the
+missing project label. Final hosted checks and marking the PR ready remain.
+Local results and coverage limits are in `record.md`; passing tests are not proof
+of soundness.
 
 ## Context and Orientation
 
@@ -194,5 +198,7 @@ and allocator traces are not part of the upstream diff.
 ## Next Action
 
 
-Push the branch to the user's fork and create the upstream draft PR. Check
-whether fork workflows need maintainer approval, then verify required checks.
+A maintainer must approve the fork workflows on PR #74 and apply the `jsonmodem`
+label. After approval, inspect the runs for the current PR head, address in-scope
+failures, and mark the PR ready only after required checks pass. Do not bypass
+approval or treat an empty check list as passing CI.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -165,10 +165,20 @@ not exist upstream; an attempt to create it returned HTTP 404. Labeling requires
 maintainer assistance.
 
 [Upstream PR #74](https://github.com/AaronFriel/jsonmodem/pull/74) was created as
-a draft from the user's fork into upstream main. GitHub reports it mergeable.
-All ten workflows for the initial published head `f99ef28` concluded
-`action_required`; no tests ran. For example, the
-[Miri run](https://github.com/AaronFriel/jsonmodem/actions/runs/32936881926) requires
-maintainer approval. The empty PR check rollup is not passing evidence. The
-publishing account has no upstream write/triage permission and cannot approve
-fork workflows. Recheck the current head after a maintainer grants approval.
+a draft from the user's fork into upstream main. On 2026-08-26, the user explicitly
+requested ready status. `gh pr ready 74 -R AaronFriel/jsonmodem` succeeded, and
+`gh pr view` confirmed `isDraft=false` at `bcce5200ff12403ae5ddc111acba3fcc6f8d785c`.
+Preserve ready status; no merge is authorized.
+
+All ten workflows for both the initial published head `f99ef28` and the
+subsequent head `bcce520` concluded `action_required`; no hosted tests ran.
+The [Miri run for bcce520](https://github.com/AaronFriel/jsonmodem/actions/runs/32936966789)
+requires maintainer approval. Ready status and the empty PR check rollup are not
+passing evidence. Hosted validation remains incomplete and must cover the final
+published head, including any later documentation commit.
+
+GitHub's repository API confirmed that the authenticated publishing account has
+admin/push permission on `friel-openai/jsonmodem` but no write/triage permission
+on `AaronFriel/jsonmodem`. The upstream PR has no labels. Workflow approval and
+creation/application of the missing `jsonmodem` label require upstream authority
+that these credentials do not have. Recheck the current head after approval.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -1,281 +1,111 @@
 # Memory-safety test evidence
 
 
-This record supports `plan.md`. Rust Miri checks passed, and the Python tests
-found two callback-related input ownership defects. Both fixes have regression
-tests and native sanitizer validation. The sections below retain the initial
-questions, failed attempts, and final evidence.
+Implementation is complete; upstream publication is in progress. Detailed test
+coverage and tool limitations are in `docs/memory-safety-testing.md`.
 
-## Baseline and independence
+## Baseline and source commits
 
 
-On 2026-08-26, fetching `upstream/main` selected
-`47a542760f84dd402cecda6476b56dc92dae54e5`, titled
-`[codex] simplify python streaming api (#72)`. Branch
-`dev/friel/memory-safety-tests` starts at that exact commit.
+The branch starts at upstream `47a542760f84dd402cecda6476b56dc92dae54e5`.
+`7883dad` adds the test infrastructure and a failing exporter regression before
+changing production behavior. `2e61d8fabc0930bed8323e10124b1e197a099280` fixes
+buffer ownership and avoids repeated attribute-name allocations. The branch
+does not contain the separate orjson frontend commits.
 
-The existing frontend branch was at
-`456eec582a6958e40fffa301469570468d2a3f02`. Comparing the relevant files showed no
-change to `.github/workflows/miri.yml`, `.config/nextest.toml`, or
-`crates/jsonmodem/src/backend/std/value_zipper.rs`. The scanner difference changes
-numeric accumulation, not the four unchecked UTF-8 conversions. Python buffer
-code exists upstream, although PR #1 also modifies `lib.rs`. Conclusion: the
-planned test infrastructure and upstream streaming tests do not require PR #1.
+The baseline scanner and Python suites each passed 27 tests. Miri excluded
+`jsonmodem-py` and the fuzz executables. Snapshot-based values and buffers tests
+were compiled out, although some adapter regression tests remained enabled.
+The new tests use plain assertions and record their generated-input count.
 
-The original checkout had uncommitted README and performance-record changes and
-an active security-audit plan. Those files were not modified by this setup.
-
-## Observed coverage gaps
+## Reproduced defects
 
 
-`.github/workflows/miri.yml` runs:
+`with_readonly_byte_text` acquired input once for text, then called
+`PyMemoryView::from(data)` for payload storage. A Python 3.12 exporter returning
+`b'["first"]'` on the first two acquisitions and `b'["second"]'` on the third
+produced `b'secon'`. The regression failed before the fix with
+`b'secon' != b'first'`. Parsing now uses the exact retained export. Unknown
+read-only exporters are snapshotted into immutable bytes before Rust borrows.
 
-    cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+`with_buffer_text` held a borrowed string while Python allocations could trigger
+garbage collection. On Python 3.9.25, a GC callback changed an ASCII byte in a
+bytearray during `feed()`, changing the last parsed string from `abc` to `abz`.
+The callback verified it ran inside feed by observing PyO3's mutable-borrow error
+when reading `parser.is_finished`. The baseline subprocess ran nine such
+callbacks and failed the unchanged-text assertion. The fixed subprocess passes
+for both bytearray and memoryview input. Mutable or unverifiable input is copied
+before parsing; exact bytes-backed storage remains borrowed.
 
-`crates/jsonmodem/tests/jsonmodem_values/mod.rs` and
-`crates/jsonmodem/tests/jsonmodem_buffers/mod.rs` disable their test modules under
-Miri because snapshot rendering accesses the filesystem. Other values and
-buffers regression cases remain enabled; do not describe all adapter tests as
-excluded.
+Independent review also reproduced mutation to invalid UTF-8 in an isolated
+process. AddressSanitizer did not diagnose that invariant violation. The checked-in
+regressions use ASCII mutation or different immutable buffers, so they detect
+the defects without deliberately constructing invalid Rust strings.
 
-`crates/jsonmodem/src/tests/property_partition.rs` and
-`crates/jsonmodem/src/tests/property_multivalue.rs` request ten cases under Miri,
-10,000 in ordinary CI, and 1,000 locally unless fast mode is selected.
-ValueZipper has no dedicated unit-test module at this base.
+The source review found both fixes closed and no further defect in the launcher,
+instrumentation verification, or Rust tests. This judgment is separate from
+execution evidence and does not remove the documented limitations.
 
-The previously inspected Miri job for PR #1 reported 181 passed and four skipped:
-https://github.com/friel-openai/jsonmodem/actions/runs/32927577857/job/98053439599
-That is historical evidence for PR #1, not a test run of this independent branch.
-The excluded Python crate and compiled-out tests are not counted among the four
-skipped tests.
-
-## Initial unsafe-operation inventory
-
-
-In `crates/jsonmodem/src/parser/scanner/mod.rs`, unchecked UTF-8 conversions are
-at base lines 340, 605, 632, and 655. The required assumption is that each selected
-byte range is valid UTF-8. Map the functions and enforcing callers before adding
-test-only validation and split-input tests.
-
-In `crates/jsonmodem/src/backend/std/value_zipper.rs`, unsafe reference creation
-or pointer dereferences occur at base lines 62, 70, 91, 115, and 124. Review
-`with_leaf_mut`, `with_leaf`, `align_path`, and `current_ptr` together with
-`descend_one`. Test pointer validity when arrays or maps grow and old descendants
-are discarded. Tests must respect, or explicitly test enforcement of, the
-one-level depth transition assumption.
-
-In `crates/jsonmodem-py/src/lib.rs`, inspect the Python object operations at base
-lines 184, 316, 373, and 798 and all buffer operations near lines 3689-3834.
-Name each reference ownership rule, successful acquisition/release pair, and
-error cleanup rule. `with_buffer_text` and `with_readonly_byte_text` construct
-slices from exporter-supplied pointers and lengths. Negative lengths and some
-read-only/layout conditions are checked; these checks alone do not establish
-allocation validity. This inventory identifies review work, not confirmed bugs.
-
-## Tool assumptions
+## Validation
 
 
-The [Miri documentation](https://github.com/rust-lang/miri) describes default
-Stacked Borrows checks, optional Tree Borrows, execution seeds, and explicit
-environment forwarding under isolation. It also explains that most foreign
-function calls are unsupported and that a passing run is not proof of soundness.
-Consulted 2026-08-26. Record the installed nightly before choosing final flags.
+Rust nightly: `1.100.0-nightly (e7769602a 2026-08-24)`, LLVM 23.1.0.
+The existing stable checks used Rust 1.94.1. Local commands:
 
-The [Rust sanitizer documentation](https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html)
-describes native instrumentation. The extension build and compatible runtime
-still need to be demonstrated. Do not label ordinary Python tests as sanitizer
-coverage or assume CPython is instrumented because the Rust extension is.
+    .agent/check.sh
+    .agent/check-py.sh
+    cargo clippy -p jsonmodem-py -- -D warnings
+    cargo test -p jsonmodem --release --lib memory_safety
+    cargo test -p jsonmodem --release --test memory_safety
+    MIRIFLAGS=-Zmiri-env-set=JSONMODEM_SAFETY_CASES=32 cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+    bash .agent/check-miri.sh targeted
+    JSONMODEM_MEMORY_PYTHON=3.9 bash .agent/check-py-memory.sh
+    JSONMODEM_MEMORY_PYTHON=3.13 bash .agent/check-py-memory.sh
 
-## First planned attempt
+The ordinary Rust check script, Python build/tests, Clippy, workflow linting, and
+release-mode safety tests passed. Miri's full suite passed 188 tests, with four
+ignored debug helpers, in 242.313 seconds. Excluded crates and compiled-out
+snapshot tests are additional omissions, not part of those four.
 
+All six targeted Miri configurations passed: Stacked Borrows and Tree Borrows,
+each with execution seeds 0, 1, and 2. Each configuration ran six unit tests and
+four integration tests, including 32 deterministic generated cases. Unit tests
+took about 8.5 seconds and integration tests about 98.5 seconds.
 
-Question: which safety assumptions have no direct executed test on upstream?
-Method: finish the function-level inventory, run the existing focused scanner
-tests, and capture actual Miri test names. No runtime code changes in this step.
-Expected evidence: a named test or an explicit omission for every unsafe
-operation in the three source files, plus baseline command results.
-Decision rule: add tests for missing cases before considering production edits;
-preserve a failing input if a check finds a defect.
+Native checks first detected the deliberately invalid test library's
+heap-buffer-overflow, then verified the installed extension referenced
+`__asan_init`. Python 3.9.25 passed 47 tests, skipping five Python-defined-exporter
+cases requiring Python 3.12. Its GC regression exercised callbacks inside feed.
+Python 3.13.14 passed 52 tests. These results include the final ownership and
+attribute-name changes.
 
-Next action: complete the inventory and run
-`cargo test -p jsonmodem --lib parser::scanner::tests` from this worktree.
-
-## Rust baseline and direct tests
-
-
-The unmodified scanner suite passed 27 tests and the unmodified Python suite
-passed 27 tests. The initial six new Rust unit tests passed normally. All three
-new ValueZipper tests also passed under Miri's default reference model. Toolchain:
-`rustc 1.100.0-nightly (e7769602a 2026-08-24)`, LLVM 23.1.0. Miri and rust-src were
-installed for that existing nightly toolchain.
-
-No production defect was demonstrated by those direct tests. Four test/Miri-only
-UTF-8 assertions were added before the scanner's unchecked conversions. A
-should-panic test passes invalid bytes to the private ASCII append helper and
-confirms failure before unchecked conversion. Release builds without Miri do not
-include those assertions.
-
-The new integration test required an explicit Cargo test target because this
-crate disables automatic test discovery. It has now been registered; compiling
-a file without registering its test target would not count as coverage.
-
-## Native memory checker experiment
+## Test and instrumentation decisions
 
 
-Question: can the Rust extension and Python entry point share the exact same
-AddressSanitizer runtime? The installed Rust nightly supplies its static runtime,
-not a matching Clang shared library. Build a small test-only Rust executable
-with AddressSanitizer that calls CPython's `Py_BytesMain`, then load the extension
-built with the same nightly and sanitizer flags. Use a separate installed wheel
-and virtual environment, not an editable build that would replace the regular
-extension in the source tree. CPython itself remains uninstrumented.
+Four scanner assertions validate UTF-8 before unchecked conversion in test/Miri
+builds only. A should-panic test confirms the assertion runs before conversion.
+Direct zipper tests cover array/map growth, siblings, replacements, root reads,
+and root reuse. Integration tests exercise actual streaming adapters.
 
-Decision rule: retain this arrangement only if a separately loaded, deliberately
-bad Rust test library produces an AddressSanitizer error in a subprocess and the
-real extension imports and runs normally. Keep deliberate bad code in the test
-tooling only, never the production extension. Record failures without claiming
-instrumentation coverage until this check works.
+An initial Miri attempt used long combined inputs and partial snapshots after
+every feed. It was stopped, not counted as passing. Shorter inputs retain every
+valid split position; separate tests cover container growth and partial values.
 
-Result: the launcher detected the deliberate heap-buffer-overflow and the
-instrumented extension passed the then-current 46 Python tests. A second run
-also verified an `__asan_init` reference in the installed extension and passed
-46 tests. Four more tests have since been added for byte mutations, buffer
-layouts, retained exporter ownership, and failed export. Final rerun pending.
+The native launcher and extension share Rust's AddressSanitizer runtime.
+CPython and the prebuilt Rust standard library are uninstrumented. Leak checking
+is disabled for CPython shutdown allocations. Explicit buffer-release tests do
+not prove general leak freedom. Tests do not inject every allocation failure,
+fabricate invalid native exporter pointers, or establish safety under concurrent
+mutation by another native extension. No passing result is a proof of soundness.
 
-CPython and the prebuilt Rust standard library are not instrumented. Leak
-detection is explicitly disabled for CPython shutdown allocations. The checked
-properties include actual access checks in the extension and explicit buffer
-release assertions; no general leak-freedom claim is made.
-
-## Function-level inventory and enforcement
+## Measurement method
 
 
-Scanner `finish`, `switch_to_owned_prefix_if_needed`, and
-`copy_prefix_to_scratch`: input comes from a Rust string, and the anchor/cursor
-must be at character boundaries. `memory_safety_prefix_copy_operations` forces
-each copy with ASCII and two-, three-, and four-byte characters. Each unchecked
-conversion now has an active test/Miri assertion. `push_ascii_to_scratch` relies
-on callers selecting ASCII; `memory_safety_owned_ascii_and_raw_captures` and the
-intentional assertion-failure test exercise both storage variants and rejection.
-
-ValueZipper `with_leaf_mut` and `with_leaf`: the raw pointer was just obtained
-from the live leaf; borrowing the separate path vector cannot move that leaf.
-Returned references borrow the zipper. `align_path` has three raw dereferences:
-descent from the current node, descent after discarding a sibling pointer, and
-returning the current pointer. The direct array/map/replacement tests exercise
-all three. `take_root` clears cached pointers before moving the root. The
-integration tests exercise these operations through actual parser sequences.
-
-Python `build_view_event`, `build_path_tuple`, `build_path_tuple_for_event`, and
-`PyPathView::tuple_range_object`: each tuple starts private and empty; indices
-are bounded by its size. `PyTuple_SetItem` takes ownership of one reference per
-slot. Failure decrements the partly built tuple. Successful pointers are
-converted to an owned PyO3 reference once. Nested retained events, path slicing,
-`as_tuple`, and byte-view tests exercise successful construction and ownership.
-OOM failure at each individual allocation is not injected; those branches were
-reviewed, not executed deliberately.
-
-Python `supports_buffer_protocol`, `with_buffer_text`, and
-`with_readonly_byte_text`: GetBuffer receives a live Python object under the
-interpreter lock and a correctly initialized C-layout descriptor. Error clearing
-occurs with that lock held after failed acquisition. `PyBufferGuard::drop`
-releases successful exports with non-null owners. Slice construction requires a
-live readable allocation of the reported nonnegative length, and a buffer guard
-outliving the slice. The exporter contract supplies allocation validity; metadata
-checks cannot prove it. Tests cover empty buffers without dereferencing null,
-valid storage, invalid UTF-8, writable/read-only restrictions, failed acquisition,
-and matched releases. A returned memoryview retains an independent export after
-the temporary guard is released. Native exporters that violate the CPython
-contract remain outside tested guarantees. This paragraph describes the initial
-review; the fixes below replace mutable borrows with snapshots and give unknown
-read-only exporters snapshot-backed payloads.
-
-`docs/memory-safety-testing.md` provides the durable user-facing inventory.
-
-## Test cost and validation
-
-
-The first exhaustive split-input test combined several features into long
-documents and requested partial snapshots after every feed. The Miri run was
-stopped before completion. It is not passing evidence. The test now uses short
-documents for each feature and only final snapshots for comparisons. A separate
-test checks partial snapshots. This keeps every valid split position while
-avoiding redundant copying. Generated inputs still use 32 deterministic cases;
-each grows an object with a nested array, and direct tests separately exercise
-64-element arrays and 64-key maps.
-
-`.agent/check.sh` passed build, Rust tests, Clippy, documentation, and the Miri-cfg
-Clippy pass, then initially stopped because actionlint was not on PATH. Running
-with `$HOME/go/bin` on PATH passed the entire script. This is ordinary test and
-lint evidence, not Miri execution. The six new unit tests and four integration
-tests also passed in release mode before the corpus was shortened. Final source
-validation remains pending.
-
-## Confirmed Python exporter reacquisition defect
-
-
-Independent review identified a callback between UTF-8 validation and parsing:
-`with_readonly_byte_text` acquires the input once to obtain text, then calls
-`PyMemoryView::from(data)` to obtain payload storage. Python 3.12 buffer exporters
-can return different storage or mutate their storage during that second call.
-The earlier input classification also acquires an export, making the unsafe
-reacquisition the third Python callback in a normal single-input feed.
-
-The reviewer reproduced mutation to invalid UTF-8 in an isolated sanitizer
-process. ASan did not report it: it checks allocation access, not UTF-8 validity.
-A non-UB regression is being added before the fix: return immutable
-`b'["first"]'` for the first two acquisitions and `b'["second"]'` for the third.
-Current parsing yields a string payload `b'secon'`, combining a range from the
-first export with storage from the second. Expected result after the fix is
-`b'first'` from one retained export.
-
-Next action: run this regression against the baseline extension, then ensure
-parsing and returned memoryviews share the exact same acquired storage. Review
-whether GC callbacks can mutate other accepted backing storage during parsing
-before deciding whether additional snapshots are required.
-
-The safe regression failed on the baseline extension exactly as expected:
-`b'secon' != b'first'`. Test-infrastructure commit `7883dad` retains this failing
-regression before any production fix.
-
-The reviewer also reproduced synchronous GC mutation on Python 3.9.25. A
-`gc.callbacks` function changed one ASCII byte only when reading
-`parser.is_finished` raised PyO3's mutable-borrow error, proving the callback ran
-inside `feed`. The parsed last string changed from `abc` to `abz`. The primary
-agent independently reproduced the safe ASCII case with
-`target/memory-baseline-py39/bin/python scripts/gc_buffer_regression.py`: nine
-callbacks ran inside feed and the unchanged-text assertion failed. No such
-callback ran inside feed in the reviewer's 3.12/3.13 tests. The regression is a
-subprocess so global GC settings and any interpreter fault remain isolated.
-
-The fix snapshots mutable or unverifiable ordinary buffer input before Python
-allocations can run callbacks. Exact bytes-backed memoryviews remain borrowed,
-as does the existing bytes fast case. Byte-view parsing first acquires the
-retained memoryview, then inspects that exact export. Unknown read-only exporters
-are copied to immutable bytes before parsing; their payloads retain that copy.
-This preserves acceptance of valid exporters without promising no-copy access to
-unverifiable storage. Direct mutable memoryviews remain rejected in byte-view mode.
-
-## Buffer-fix performance experiment
-
-
-Question: how much do immutable-owner checking and required snapshots cost for
-chunked streaming input? Baseline: a release wheel built from the production
-code at `7883dad`, installed separately in `target/memory-benchmark-baseline`.
-Candidate: this worktree's ordinary release extension. Use the public
-`make_array_strings(1024)` workload and event loop from
-`benchmarks/bench_jiter_chunked.py`, with 512-byte chunks. Compare bytes,
-bytearray, bytes-backed memoryviews, and byte-view mode with bytes and a Python
-read-only exporter. Run both interpreters alternately for seven pairs, recording
-time per complete stream. Use Memray native allocation tracking separately for
-100 streams; record allocation counts and peak tracked bytes. No orjson result
-is needed for this safety-only comparison.
-
-Decision rule: bytes must retain its no-copy behavior; measure any regression
-and reduce avoidable copies or callback work without removing required ownership.
-Do not interpret shared-host timings as a release performance guarantee. Keep
-generated timing/allocation artifacts outside tracked files. Next action: run
-the paired baseline/candidate experiment after regression tests pass.
+Before measuring, the question was whether immutable-owner checks and snapshots
+slow chunked input or add avoidable allocations. The decision rule was to retain
+borrowing of known immutable storage and remove unnecessary copying or callback
+work without weakening ownership. The comparison below uses the existing public
+array-of-strings workload and separate timing and Memray runs.
 
 ## Final measurements
 
@@ -325,38 +155,11 @@ Python exporter needs a snapshot but avoids reacquiring another export, leaving
 the measured allocation count unchanged. Peak tracked memory is not RSS.
 No claim about orjson performance follows from this safety-fix comparison.
 
-## Final validation
+## Publication
 
 
-`cargo +nightly miri nextest run --workspace --profile default-miri --exclude
-jsonmodem-fuzz --exclude jsonmodem-py` with an explicitly forwarded 32-case setting
-passed 188 tests, with four ignored debug helpers, in 242.313 seconds. Snapshot
-tests compiled out under Miri and excluded crates are additional omissions.
-
-`bash .agent/check-miri.sh targeted` passed all six configurations: Stacked
-Borrows and Tree Borrows, each with execution seeds 0, 1, and 2. Every configuration
-ran six unit tests and four integration tests, including 32 generated cases.
-Unit tests took about 8.5 seconds; integration tests took about 98.5 seconds.
-These results validate the final Rust test behavior; subsequent source edits
-were limited to Python buffer handling, comments, and equivalent formatting.
-
-The ordinary Rust check script, release-mode safety tests, Python build/tests,
-and Python Clippy check passed. The default check script still does not run Miri
-unless requested; the actual Miri runs above provide that evidence separately.
-
-Native checks passed the required deliberate heap-buffer-overflow detection and
-then verified the installed extension's sanitizer symbol. Python 3.9.25 passed
-47 tests, skipping five Python-defined-exporter cases that require 3.12. Its GC
-regression exercised callbacks inside feed. The final Python 3.13.14 rerun passed
-52 tests. Both interpreter runs include the final attribute-name allocation
-change. Python 3.9 skips only the five tests requiring Python 3.12 buffer methods.
-
-An independent source review found the two Python defects, then reviewed the
-fixes and found both closed. It found no additional defect in the launcher,
-instrumentation verification, or Rust tests. The source-review conclusion is
-separate from actual test results and does not remove the documented limitations.
-
-Final source commit: `2e61d8fabc0930bed8323e10124b1e197a099280`. The original PR's
-commits are not ancestors of this branch. No new PR or hosted CI run was
-requested. The workflow definitions passed actionlint; their commands were
-executed locally as recorded above. Next action: publication only if requested.
+On 2026-08-26, upstream main was refreshed and remained at `47a5427`. The branch
+was clean and no matching upstream PR existed. The publishing account is
+`friel-openai`, with read-only upstream permission. The `jsonmodem` label does
+not exist upstream; an attempt to create it returned HTTP 404. Labeling requires
+maintainer assistance. Creating the draft PR and checking its workflows are next.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -1,0 +1,230 @@
+# Memory-safety test evidence
+
+
+This record supports `plan.md`. No new tests have been run for this branch yet.
+
+## Baseline and independence
+
+
+On 2026-08-26, fetching `upstream/main` selected
+`47a542760f84dd402cecda6476b56dc92dae54e5`, titled
+`[codex] simplify python streaming api (#72)`. Branch
+`dev/friel/memory-safety-tests` starts at that exact commit.
+
+The existing frontend branch was at
+`456eec582a6958e40fffa301469570468d2a3f02`. Comparing the relevant files showed no
+change to `.github/workflows/miri.yml`, `.config/nextest.toml`, or
+`crates/jsonmodem/src/backend/std/value_zipper.rs`. The scanner difference changes
+numeric accumulation, not the four unchecked UTF-8 conversions. Python buffer
+code exists upstream, although PR #1 also modifies `lib.rs`. Conclusion: the
+planned test infrastructure and upstream streaming tests do not require PR #1.
+
+The original checkout had uncommitted README and performance-record changes and
+an active security-audit plan. Those files were not modified by this setup.
+
+## Observed coverage gaps
+
+
+`.github/workflows/miri.yml` runs:
+
+    cargo +nightly miri nextest run --workspace --profile default-miri --exclude jsonmodem-fuzz --exclude jsonmodem-py
+
+`crates/jsonmodem/tests/jsonmodem_values/mod.rs` and
+`crates/jsonmodem/tests/jsonmodem_buffers/mod.rs` disable their test modules under
+Miri because snapshot rendering accesses the filesystem. Other values and
+buffers regression cases remain enabled; do not describe all adapter tests as
+excluded.
+
+`crates/jsonmodem/src/tests/property_partition.rs` and
+`crates/jsonmodem/src/tests/property_multivalue.rs` request ten cases under Miri,
+10,000 in ordinary CI, and 1,000 locally unless fast mode is selected.
+ValueZipper has no dedicated unit-test module at this base.
+
+The previously inspected Miri job for PR #1 reported 181 passed and four skipped:
+https://github.com/friel-openai/jsonmodem/actions/runs/32927577857/job/98053439599
+That is historical evidence for PR #1, not a test run of this independent branch.
+The excluded Python crate and compiled-out tests are not counted among the four
+skipped tests.
+
+## Initial unsafe-operation inventory
+
+
+In `crates/jsonmodem/src/parser/scanner/mod.rs`, unchecked UTF-8 conversions are
+at base lines 340, 605, 632, and 655. The required assumption is that each selected
+byte range is valid UTF-8. Map the functions and enforcing callers before adding
+test-only validation and split-input tests.
+
+In `crates/jsonmodem/src/backend/std/value_zipper.rs`, unsafe reference creation
+or pointer dereferences occur at base lines 62, 70, 91, 115, and 124. Review
+`with_leaf_mut`, `with_leaf`, `align_path`, and `current_ptr` together with
+`descend_one`. Test pointer validity when arrays or maps grow and old descendants
+are discarded. Tests must respect, or explicitly test enforcement of, the
+one-level depth transition assumption.
+
+In `crates/jsonmodem-py/src/lib.rs`, inspect the Python object operations at base
+lines 184, 316, 373, and 798 and all buffer operations near lines 3689-3834.
+Name each reference ownership rule, successful acquisition/release pair, and
+error cleanup rule. `with_buffer_text` and `with_readonly_byte_text` construct
+slices from exporter-supplied pointers and lengths. Negative lengths and some
+read-only/layout conditions are checked; these checks alone do not establish
+allocation validity. This inventory identifies review work, not confirmed bugs.
+
+## Tool assumptions
+
+
+The [Miri documentation](https://github.com/rust-lang/miri) describes default
+Stacked Borrows checks, optional Tree Borrows, execution seeds, and explicit
+environment forwarding under isolation. It also explains that most foreign
+function calls are unsupported and that a passing run is not proof of soundness.
+Consulted 2026-08-26. Record the installed nightly before choosing final flags.
+
+The [Rust sanitizer documentation](https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html)
+describes native instrumentation. The extension build and compatible runtime
+still need to be demonstrated. Do not label ordinary Python tests as sanitizer
+coverage or assume CPython is instrumented because the Rust extension is.
+
+## First planned attempt
+
+
+Question: which safety assumptions have no direct executed test on upstream?
+Method: finish the function-level inventory, run the existing focused scanner
+tests, and capture actual Miri test names. No runtime code changes in this step.
+Expected evidence: a named test or an explicit omission for every unsafe
+operation in the three source files, plus baseline command results.
+Decision rule: add tests for missing cases before considering production edits;
+preserve a failing input if a check finds a defect.
+
+Next action: complete the inventory and run
+`cargo test -p jsonmodem --lib parser::scanner::tests` from this worktree.
+
+## Rust baseline and direct tests
+
+
+The unmodified scanner suite passed 27 tests and the unmodified Python suite
+passed 27 tests. The initial six new Rust unit tests passed normally. All three
+new ValueZipper tests also passed under Miri's default reference model. Toolchain:
+`rustc 1.100.0-nightly (e7769602a 2026-08-24)`, LLVM 23.1.0. Miri and rust-src were
+installed for that existing nightly toolchain.
+
+No production defect was demonstrated by those direct tests. Four test/Miri-only
+UTF-8 assertions were added before the scanner's unchecked conversions. A
+should-panic test passes invalid bytes to the private ASCII append helper and
+confirms failure before unchecked conversion. Release builds without Miri do not
+include those assertions.
+
+The new integration test required an explicit Cargo test target because this
+crate disables automatic test discovery. It has now been registered; compiling
+a file without registering its test target would not count as coverage.
+
+## Native memory checker experiment
+
+
+Question: can the Rust extension and Python entry point share the exact same
+AddressSanitizer runtime? The installed Rust nightly supplies its static runtime,
+not a matching Clang shared library. Build a small test-only Rust executable
+with AddressSanitizer that calls CPython's `Py_BytesMain`, then load the extension
+built with the same nightly and sanitizer flags. Use a separate installed wheel
+and virtual environment, not an editable build that would replace the regular
+extension in the source tree. CPython itself remains uninstrumented.
+
+Decision rule: retain this arrangement only if a separately loaded, deliberately
+bad Rust test library produces an AddressSanitizer error in a subprocess and the
+real extension imports and runs normally. Keep deliberate bad code in the test
+tooling only, never the production extension. Record failures without claiming
+instrumentation coverage until this check works.
+
+Result: the launcher detected the deliberate heap-buffer-overflow and the
+instrumented extension passed the then-current 46 Python tests. A second run
+also verified an `__asan_init` reference in the installed extension and passed
+46 tests. Four more tests have since been added for byte mutations, buffer
+layouts, retained exporter ownership, and failed export. Final rerun pending.
+
+CPython and the prebuilt Rust standard library are not instrumented. Leak
+detection is explicitly disabled for CPython shutdown allocations. The checked
+properties include actual access checks in the extension and explicit buffer
+release assertions; no general leak-freedom claim is made.
+
+## Function-level inventory and enforcement
+
+
+Scanner `finish`, `switch_to_owned_prefix_if_needed`, and
+`copy_prefix_to_scratch`: input comes from a Rust string, and the anchor/cursor
+must be at character boundaries. `memory_safety_prefix_copy_operations` forces
+each copy with ASCII and two-, three-, and four-byte characters. Each unchecked
+conversion now has an active test/Miri assertion. `push_ascii_to_scratch` relies
+on callers selecting ASCII; `memory_safety_owned_ascii_and_raw_captures` and the
+intentional assertion-failure test exercise both storage variants and rejection.
+
+ValueZipper `with_leaf_mut` and `with_leaf`: the raw pointer was just obtained
+from the live leaf; borrowing the separate path vector cannot move that leaf.
+Returned references borrow the zipper. `align_path` has three raw dereferences:
+descent from the current node, descent after discarding a sibling pointer, and
+returning the current pointer. The direct array/map/replacement tests exercise
+all three. `take_root` clears cached pointers before moving the root. The
+integration tests exercise these operations through actual parser sequences.
+
+Python `build_view_event`, `build_path_tuple`, `build_path_tuple_for_event`, and
+`PyPathView::tuple_range_object`: each tuple starts private and empty; indices
+are bounded by its size. `PyTuple_SetItem` takes ownership of one reference per
+slot. Failure decrements the partly built tuple. Successful pointers are
+converted to an owned PyO3 reference once. Nested retained events, path slicing,
+`as_tuple`, and byte-view tests exercise successful construction and ownership.
+OOM failure at each individual allocation is not injected; those branches were
+reviewed, not executed deliberately.
+
+Python `supports_buffer_protocol`, `with_buffer_text`, and
+`with_readonly_byte_text`: GetBuffer receives a live Python object under the
+interpreter lock and a correctly initialized C-layout descriptor. Error clearing
+occurs with that lock held after failed acquisition. `PyBufferGuard::drop`
+releases successful exports with non-null owners. Slice construction requires a
+live readable allocation of the reported nonnegative length, and a buffer guard
+outliving the slice. The exporter contract supplies allocation validity; metadata
+checks cannot prove it. Tests cover empty buffers without dereferencing null,
+valid storage, invalid UTF-8, writable/read-only restrictions, failed acquisition,
+and matched releases. A returned memoryview retains an independent export after
+the temporary guard is released. Native exporters that violate the CPython
+contract remain outside tested guarantees.
+
+`docs/memory-safety-testing.md` provides the durable user-facing inventory.
+
+## Test cost and validation
+
+
+The first exhaustive split-input test combined several features into long
+documents and requested partial snapshots after every feed. The Miri run was
+stopped before completion. It is not passing evidence. The test now uses short
+documents for each feature and only final snapshots for comparisons. A separate
+test checks partial snapshots. This keeps every valid split position while
+avoiding redundant copying. Generated inputs still use 32 deterministic cases;
+each grows an object with a nested array, and direct tests separately exercise
+64-element arrays and 64-key maps.
+
+`.agent/check.sh` passed build, Rust tests, Clippy, documentation, and the Miri-cfg
+Clippy pass, then initially stopped because actionlint was not on PATH. Running
+with `$HOME/go/bin` on PATH passed the entire script. This is ordinary test and
+lint evidence, not Miri execution. The six new unit tests and four integration
+tests also passed in release mode before the corpus was shortened. Final source
+validation remains pending.
+
+## Confirmed Python exporter reacquisition defect
+
+
+Independent review identified a callback between UTF-8 validation and parsing:
+`with_readonly_byte_text` acquires the input once to obtain text, then calls
+`PyMemoryView::from(data)` to obtain payload storage. Python 3.12 buffer exporters
+can return different storage or mutate their storage during that second call.
+The earlier input classification also acquires an export, making the unsafe
+reacquisition the third Python callback in a normal single-input feed.
+
+The reviewer reproduced mutation to invalid UTF-8 in an isolated sanitizer
+process. ASan did not report it: it checks allocation access, not UTF-8 validity.
+A non-UB regression is being added before the fix: return immutable
+`b'["first"]'` for the first two acquisitions and `b'["second"]'` for the third.
+Current parsing yields a string payload `b'secon'`, combining a range from the
+first export with storage from the second. Expected result after the fix is
+`b'first'` from one retained export.
+
+Next action: run this regression against the baseline extension, then ensure
+parsing and returned memoryviews share the exact same acquired storage. Review
+whether GC callbacks can mutate other accepted backing storage during parsing
+before deciding whether additional snapshots are required.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -162,4 +162,13 @@ On 2026-08-26, upstream main was refreshed and remained at `47a5427`. The branch
 was clean and no matching upstream PR existed. The publishing account is
 `friel-openai`, with read-only upstream permission. The `jsonmodem` label does
 not exist upstream; an attempt to create it returned HTTP 404. Labeling requires
-maintainer assistance. Creating the draft PR and checking its workflows are next.
+maintainer assistance.
+
+[Upstream PR #74](https://github.com/AaronFriel/jsonmodem/pull/74) was created as
+a draft from the user's fork into upstream main. GitHub reports it mergeable.
+All ten workflows for the initial published head `f99ef28` concluded
+`action_required`; no tests ran. For example, the
+[Miri run](https://github.com/AaronFriel/jsonmodem/actions/runs/32936881926) requires
+maintainer approval. The empty PR check rollup is not passing evidence. The
+publishing account has no upstream write/triage permission and cannot approve
+fork workflows. Recheck the current head after a maintainer grants approval.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -1,7 +1,10 @@
 # Memory-safety test evidence
 
 
-This record supports `plan.md`. No new tests have been run for this branch yet.
+This record supports `plan.md`. Rust Miri checks passed, and the Python tests
+found two callback-related input ownership defects. Both fixes have regression
+tests and native sanitizer validation. The sections below retain the initial
+questions, failed attempts, and final evidence.
 
 ## Baseline and independence
 
@@ -183,7 +186,9 @@ checks cannot prove it. Tests cover empty buffers without dereferencing null,
 valid storage, invalid UTF-8, writable/read-only restrictions, failed acquisition,
 and matched releases. A returned memoryview retains an independent export after
 the temporary guard is released. Native exporters that violate the CPython
-contract remain outside tested guarantees.
+contract remain outside tested guarantees. This paragraph describes the initial
+review; the fixes below replace mutable borrows with snapshots and give unknown
+read-only exporters snapshot-backed payloads.
 
 `docs/memory-safety-testing.md` provides the durable user-facing inventory.
 
@@ -228,3 +233,123 @@ Next action: run this regression against the baseline extension, then ensure
 parsing and returned memoryviews share the exact same acquired storage. Review
 whether GC callbacks can mutate other accepted backing storage during parsing
 before deciding whether additional snapshots are required.
+
+The safe regression failed on the baseline extension exactly as expected:
+`b'secon' != b'first'`. Test-infrastructure commit `7883dad` retains this failing
+regression before any production fix.
+
+The reviewer also reproduced synchronous GC mutation on Python 3.9.25. A
+`gc.callbacks` function changed one ASCII byte only when reading
+`parser.is_finished` raised PyO3's mutable-borrow error, proving the callback ran
+inside `feed`. The parsed last string changed from `abc` to `abz`. The primary
+agent independently reproduced the safe ASCII case with
+`target/memory-baseline-py39/bin/python scripts/gc_buffer_regression.py`: nine
+callbacks ran inside feed and the unchanged-text assertion failed. No such
+callback ran inside feed in the reviewer's 3.12/3.13 tests. The regression is a
+subprocess so global GC settings and any interpreter fault remain isolated.
+
+The fix snapshots mutable or unverifiable ordinary buffer input before Python
+allocations can run callbacks. Exact bytes-backed memoryviews remain borrowed,
+as does the existing bytes fast case. Byte-view parsing first acquires the
+retained memoryview, then inspects that exact export. Unknown read-only exporters
+are copied to immutable bytes before parsing; their payloads retain that copy.
+This preserves acceptance of valid exporters without promising no-copy access to
+unverifiable storage. Direct mutable memoryviews remain rejected in byte-view mode.
+
+## Buffer-fix performance experiment
+
+
+Question: how much do immutable-owner checking and required snapshots cost for
+chunked streaming input? Baseline: a release wheel built from the production
+code at `7883dad`, installed separately in `target/memory-benchmark-baseline`.
+Candidate: this worktree's ordinary release extension. Use the public
+`make_array_strings(1024)` workload and event loop from
+`benchmarks/bench_jiter_chunked.py`, with 512-byte chunks. Compare bytes,
+bytearray, bytes-backed memoryviews, and byte-view mode with bytes and a Python
+read-only exporter. Run both interpreters alternately for seven pairs, recording
+time per complete stream. Use Memray native allocation tracking separately for
+100 streams; record allocation counts and peak tracked bytes. No orjson result
+is needed for this safety-only comparison.
+
+Decision rule: bytes must retain its no-copy behavior; measure any regression
+and reduce avoidable copies or callback work without removing required ownership.
+Do not interpret shared-host timings as a release performance guarantee. Keep
+generated timing/allocation artifacts outside tracked files. Next action: run
+the paired baseline/candidate experiment after regression tests pass.
+
+## Final measurements
+
+
+The first measurement found avoidable allocations from repeatedly constructing
+the Python attribute name `obj`. The fix now interns that name and reads a
+byte-view owner's attribute only once. This removed those per-chunk allocations
+without weakening the ownership checks.
+
+The reproducible comparison is now
+`crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py`. Command:
+
+    .venv/bin/python crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py --baseline-python target/memory-benchmark-baseline/bin/python --candidate-python .venv/bin/python
+
+The baseline release wheel contains production code from `7883dad`; the candidate
+contains the buffer fixes and interned attribute name. Both used CPython 3.12.13,
+Rust 1.94.1, and Memray 1.20.0 on the same shared Linux x86_64 host, without CPU
+pinning. Seven paired timing measurements alternate execution order. Each is
+the median of three measurements of 200 streams. Each stream contains 1,024
+strings, 7,169 input bytes, 15 chunks, and 1,034 emitted events. All event counts
+matched. Memray runs are separate from timing, with 100 streams after ten warmups.
+
+| Input/mode | Baseline us/stream | Fixed us/stream | Median paired fixed/baseline | Paired ratio range |
+| --- | ---: | ---: | ---: | --- |
+| bytes, ordinary events | 365.25 | 354.69 | 0.970 | 0.955-1.024 |
+| bytearray, ordinary events | 366.36 | 365.86 | 0.986 | 0.960-1.054 |
+| bytes-backed memoryview, ordinary events | 366.70 | 358.04 | 0.981 | 0.904-0.994 |
+| bytes, byte-view events | 535.55 | 532.71 | 1.001 | 0.938-1.021 |
+| Python exporter, byte-view events | 544.51 | 551.24 | 1.003 | 0.961-1.054 |
+
+Ratios near one indicate similar timings, not proof of zero overhead. Variation
+on this shared host does not support a general speedup claim. The bytes fast
+case was not changed by the ownership fix.
+
+| Input/mode | Baseline allocations/stream | Fixed allocations/stream | Baseline peak tracked bytes | Fixed peak tracked bytes |
+| --- | ---: | ---: | ---: | ---: |
+| bytes, ordinary events | 2921.46 | 2921.46 | 11164 | 11164 |
+| bytearray, ordinary events | 2921.07 | 2936.07 | 8644 | 9084 |
+| bytes-backed memoryview, ordinary events | 2921.07 | 2921.07 | 8644 | 8644 |
+| bytes, byte-view events | 5144.07 | 5144.07 | 2902027 | 2902027 |
+| Python exporter, byte-view events | 5339.07 | 5339.07 | 2902515 | 2904596 |
+
+These counts use native and Python allocator tracing and exclude free/unmap
+records. Bytearray input adds exactly one snapshot allocation per chunk. The
+Python exporter needs a snapshot but avoids reacquiring another export, leaving
+the measured allocation count unchanged. Peak tracked memory is not RSS.
+No claim about orjson performance follows from this safety-fix comparison.
+
+## Final validation
+
+
+`cargo +nightly miri nextest run --workspace --profile default-miri --exclude
+jsonmodem-fuzz --exclude jsonmodem-py` with an explicitly forwarded 32-case setting
+passed 188 tests, with four ignored debug helpers, in 242.313 seconds. Snapshot
+tests compiled out under Miri and excluded crates are additional omissions.
+
+`bash .agent/check-miri.sh targeted` passed all six configurations: Stacked
+Borrows and Tree Borrows, each with execution seeds 0, 1, and 2. Every configuration
+ran six unit tests and four integration tests, including 32 generated cases.
+Unit tests took about 8.5 seconds; integration tests took about 98.5 seconds.
+These results validate the final Rust test behavior; subsequent source edits
+were limited to Python buffer handling, comments, and equivalent formatting.
+
+The ordinary Rust check script, release-mode safety tests, Python build/tests,
+and Python Clippy check passed. The default check script still does not run Miri
+unless requested; the actual Miri runs above provide that evidence separately.
+
+Native checks passed the required deliberate heap-buffer-overflow detection and
+then verified the installed extension's sanitizer symbol. Python 3.9.25 passed
+47 tests, skipping five Python-defined-exporter cases that require 3.12. Its GC
+regression exercised callbacks inside feed. Python 3.13.14 passed 52 tests before
+the final attribute-name allocation change; the final 3.13 rerun is pending.
+
+An independent source review found the two Python defects, then reviewed the
+fixes and found both closed. It found no additional defect in the launcher,
+instrumentation verification, or Rust tests. The source-review conclusion is
+separate from actual test results and does not remove the documented limitations.

--- a/plans/memory-safety-tests/record.md
+++ b/plans/memory-safety-tests/record.md
@@ -291,7 +291,8 @@ The reproducible comparison is now
     .venv/bin/python crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py --baseline-python target/memory-benchmark-baseline/bin/python --candidate-python .venv/bin/python
 
 The baseline release wheel contains production code from `7883dad`; the candidate
-contains the buffer fixes and interned attribute name. Both used CPython 3.12.13,
+contains the buffer fixes and interned attribute name committed in
+`2e61d8fabc0930bed8323e10124b1e197a099280`. Both used CPython 3.12.13,
 Rust 1.94.1, and Memray 1.20.0 on the same shared Linux x86_64 host, without CPU
 pinning. Seven paired timing measurements alternate execution order. Each is
 the median of three measurements of 200 streams. Each stream contains 1,024
@@ -346,10 +347,16 @@ unless requested; the actual Miri runs above provide that evidence separately.
 Native checks passed the required deliberate heap-buffer-overflow detection and
 then verified the installed extension's sanitizer symbol. Python 3.9.25 passed
 47 tests, skipping five Python-defined-exporter cases that require 3.12. Its GC
-regression exercised callbacks inside feed. Python 3.13.14 passed 52 tests before
-the final attribute-name allocation change; the final 3.13 rerun is pending.
+regression exercised callbacks inside feed. The final Python 3.13.14 rerun passed
+52 tests. Both interpreter runs include the final attribute-name allocation
+change. Python 3.9 skips only the five tests requiring Python 3.12 buffer methods.
 
 An independent source review found the two Python defects, then reviewed the
 fixes and found both closed. It found no additional defect in the launcher,
 instrumentation verification, or Rust tests. The source-review conclusion is
 separate from actual test results and does not remove the documented limitations.
+
+Final source commit: `2e61d8fabc0930bed8323e10124b1e197a099280`. The original PR's
+commits are not ancestors of this branch. No new PR or hosted CI run was
+requested. The workflow definitions passed actionlint; their commands were
+executed locally as recorded above. Next action: publication only if requested.

--- a/scripts/asan_failure.rs
+++ b/scripts/asan_failure.rs
@@ -1,0 +1,8 @@
+//! Deliberately invalid test library. Never link this into jsonmodem.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn check_address_sanitizer() -> u8 {
+    let bytes = vec![42_u8; std::hint::black_box(8)];
+    // Deliberate out-of-bounds read: the parent test requires an ASan failure.
+    unsafe { std::ptr::read_volatile(bytes.as_ptr().add(bytes.len())) }
+}

--- a/scripts/check_asan_failure.py
+++ b/scripts/check_asan_failure.py
@@ -1,0 +1,19 @@
+"""Require a sanitizer diagnostic from the deliberately invalid test library."""
+
+import pathlib
+import subprocess
+import sys
+
+
+runner, python, library, output = sys.argv[1:]
+result = subprocess.run(
+    [runner, python, "-c", "import ctypes, sys; ctypes.CDLL(sys.argv[1]).check_address_sanitizer()", library],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=60,
+)
+pathlib.Path(output).write_bytes(result.stdout)
+if result.returncode == 0 or b"ERROR: AddressSanitizer: heap-buffer-overflow" not in result.stdout:
+    sys.stderr.buffer.write(result.stdout)
+    raise SystemExit("AddressSanitizer did not detect the deliberate out-of-bounds read")
+print("AddressSanitizer detected the deliberate out-of-bounds read")

--- a/scripts/gc_buffer_regression.py
+++ b/scripts/gc_buffer_regression.py
@@ -1,0 +1,43 @@
+"""Exercise buffer mutation during CPython 3.9-3.11 synchronous collection."""
+
+import gc
+import sys
+
+from jsonmodem import JsonModem
+
+
+def check(use_view):
+    gc.disable()
+    source = bytearray(b"[" + b",".join([b'"abc"'] * 200) + b"]")
+    data = memoryview(source) if use_view else source
+    parser = JsonModem()
+    feed = parser.feed
+    callbacks_during_feed = 0
+
+    def mutate(phase, info):
+        nonlocal callbacks_during_feed
+        if phase == "start":
+            try:
+                parser.is_finished
+            except RuntimeError:
+                # PyO3 rejects this access while feed holds its mutable borrow.
+                callbacks_during_feed += 1
+                source[-3] = ord("z")
+
+    gc.callbacks.append(mutate)
+    gc.collect()
+    gc.set_threshold(20, 10000, 10000)
+    gc.enable()
+    try:
+        events = list(feed(data))
+    finally:
+        gc.disable()
+        gc.callbacks.remove(mutate)
+    print(f"memoryview={use_view}: callbacks during feed={callbacks_during_feed}")
+    if sys.version_info < (3, 12):
+        assert callbacks_during_feed > 0, "regression did not exercise synchronous GC"
+    assert events[-2][2].fragment == "abc", "callback changed the text being parsed"
+
+
+check(False)
+check(True)

--- a/scripts/python_memory_runner.rs
+++ b/scripts/python_memory_runner.rs
@@ -1,0 +1,37 @@
+//! Starts CPython with the same AddressSanitizer runtime as the tested
+//! extension.
+
+use std::{
+    env,
+    ffi::CString,
+    os::{
+        raw::{c_char, c_int},
+        unix::ffi::OsStrExt,
+    },
+};
+
+unsafe extern "C" {
+    fn Py_BytesMain(argc: c_int, argv: *mut *mut c_char) -> c_int;
+}
+
+fn main() {
+    // The first supplied argument is the virtual environment's Python executable.
+    let arguments: Vec<_> = env::args_os()
+        .skip(1)
+        .map(|argument| CString::new(argument.as_bytes()).expect("argument contains NUL"))
+        .collect();
+    assert!(
+        !arguments.is_empty(),
+        "expected Python executable and arguments"
+    );
+    let mut pointers: Vec<_> = arguments
+        .iter()
+        .map(|argument| argument.as_ptr().cast_mut())
+        .collect();
+    let argc = c_int::try_from(pointers.len()).expect("too many arguments");
+    pointers.push(std::ptr::null_mut());
+    // SAFETY: CPython reads these NUL-terminated arguments during this call.
+    // Both the strings and the writable pointer array outlive the interpreter.
+    let status = unsafe { Py_BytesMain(argc, pointers.as_mut_ptr()) };
+    std::process::exit(status);
+}


### PR DESCRIPTION
## Summary

Fix two input ownership bugs in the Python streaming API:

- A garbage-collection callback on Python 3.9 can mutate a bytearray while Rust parses a borrowed string from it. Snapshot mutable or unverifiable storage before parsing, while retaining borrowing for immutable bytes-backed input.
- Byte-view mode can parse one buffer export but construct payload views from another. Acquire the retained memoryview first and parse that exact export. Unknown read-only exporters remain accepted, with payload views backed by an immutable snapshot.

Both bugs have regressions that fail before the fixes. This also adds dedicated scanner and ValueZipper tests, test-only UTF-8 assertions, repeatable Miri checks, and Python AddressSanitizer CI for Python 3.9 and 3.13. No new production unsafe blocks or runtime dependencies are added.

## Validation

Local checks passed:

- Full Miri suite: 188 tests passed; four debug helpers ignored. Separately, ten targeted tests passed under Stacked Borrows and Tree Borrows with three execution seeds each, including 32 generated input cases per configuration.
- AddressSanitizer: 47 tests passed on Python 3.9 and 52 on Python 3.13. Five Python-defined-exporter cases are skipped on 3.9 because that feature requires 3.12. The runner first verifies that a deliberately invalid test library produces the expected sanitizer error.
- Existing Rust and Python tests, release-mode safety tests, Clippy, documentation builds, and actionlint.

Miri still excludes the CPython binding. The native checks do not instrument CPython or the prebuilt Rust standard library, and disable leak checking for interpreter shutdown allocations. Coverage and remaining limits are documented in `docs/memory-safety-testing.md`.

## Performance

Compared release builds before and after the fixes using 1,024 strings split into 512-byte chunks. Seven paired measurements alternated execution order. Median time ratios ranged from 0.970 to 1.003 across five input modes; individual pairs varied from 0.904 to 1.054. Shared-host variation does not establish a general speedup or zero overhead.

Memray allocation counts were unchanged for immutable inputs. Bytearray input added one snapshot allocation per chunk. Interning the `obj` attribute name removed avoidable per-chunk allocations from the new ownership check. The benchmark and full timing/allocation tables are included in `crates/jsonmodem-py/benchmarks/bench_buffer_inputs.py` and `plans/memory-safety-tests/record.md`.

-frielbot
